### PR TITLE
Added If statement around authentik_net in docker-compose template for tautulli container to only output when enabled

### DIFF
--- a/roles/hmsdocker/templates/docker-compose.yml.j2
+++ b/roles/hmsdocker/templates/docker-compose.yml.j2
@@ -780,7 +780,9 @@ services:
     networks:
       - "media_net"
       - "traefik_net"
+    {% if authentik_enabled_tautulli %}
       - "authentik_net"
+    {% endif %}
     environment:
       - PUID={{ container_uid }}
       - PGID={{ container_gid }}


### PR DESCRIPTION
Probably should've created an issue before this but it's a small change.

I was getting an error when playing the runbook with authentik disabled as the authentik_net is always defined for the tautulli container.