### PR TITLE
Add support for custom OVPN files

### DIFF
--- a/docs/Transmission.md
+++ b/docs/Transmission.md
@@ -1,0 +1,40 @@
+# Transmission
+
+All settings mentioned below should already exist in your `vars/custom/transmission.yml` file
+
+## Using a different VPN location or type
+
+For supported providers, you can change the server location and/or type.
+
+1. Make sure `transmission_vpn_provider` is set to your correct provider
+
+    a. You can find supported providers at [the official docs page](https://haugene.github.io/docker-transmission-openvpn/supported-providers/)
+
+2. Find your VPN providers folder in [this github repo](https://github.com/haugene/vpn-configs-contrib/tree/main/openvpn)
+
+3. Find the correct VPN config you want to use, and use this as the value for `transmission_ovpn_config_file`, and remove the `.ovpn` from the end
+
+For example, if you wanted to use the US Chicago server for mullvad:
+
+```yml
+transmission_vpn_provider: MULLVAD
+...
+transmission_ovpn_config_file: us_chi
+```
+
+## Using a local OpenVPN config file
+
+1. Change `transmission_vpn_provider` to `custom`
+
+2. Change `transmission_ovpn_config_file` to the `.ovpn` file name, and remove the `.ovpn` from the end
+
+3. Change `transmission_ovpn_config_local_path` to the folder path where the above file is stored
+
+    a. If needed by your provider/server, make sure certificate files and any others are also in the same folder
+
+For example, if you had a custom file named `test-vpn.ovpn` located in `/opt/hms-docker/vpn_configs` (this folder does not exist by default, just an example):
+
+```yml
+transmission_ovpn_config_file: test-vpn
+transmission_ovpn_config_local_path: /opt/hms-docker/vpn_configs
+```

--- a/roles/hmsdocker/defaults/main/transmission.yml
+++ b/roles/hmsdocker/defaults/main/transmission.yml
@@ -5,7 +5,7 @@ transmission_vpn_provider: ""
 transmission_vpn_user: ""
 transmission_vpn_pass: ""
 
-# Transmissoin seed ratio settings
+# Transmission seed ratio settings
 transmission_ratio_limit: "1" # default: "1"
 transmission_ratio_enabled: "true" # default: "true"
 
@@ -29,3 +29,18 @@ transmission_additional_env_vars:
     "TRANSMISSION_PEER_LIMIT_GLOBAL": "3000",
     "TRANSMISSION_PEER_LIMIT_PER_TORRENT": "300",
   }
+
+
+## External Providers and Custom VPN Options
+# These are for changing the VPN config to a different server or type for example
+# For help with these variables, see the docs located in `docs/Transmission.md`
+
+# default: ""
+transmission_ovpn_config_file: ""
+
+# default: ""
+transmission_ovpn_config_local_path: ""
+
+# The git repo where the .ovpn file is stored, see: https://github.com/haugene/vpn-configs-contrib/blob/main/CONTRIBUTING.md
+# If this is left blank, it will use the default that comes with the container # default: ""
+transmission_ovpn_config_source_repo: ""

--- a/roles/hmsdocker/templates/docker-compose.yml.j2
+++ b/roles/hmsdocker/templates/docker-compose.yml.j2
@@ -471,8 +471,12 @@ services:
       - OPENVPN_PROVIDER=${VPN_PROVIDER}
       - OPENVPN_USERNAME=${VPN_USER}
       - OPENVPN_PASSWORD=${VPN_PASS}
+      {% if transmission_github_config_source_repo != "" %}
       - GITHUB_CONFIG_SOURCE_REPO=${VPN_REPO}
+      {% endif %}
+      {% if transmission_ovpn_config != "" %}
       - OPENVPN_CONFIG=${VPN_CONFIG}
+      {% endif %}
       - OPENVPN_OPTS=--inactive 3600 --ping 10 --ping-exit 60
       - TRANSMISSION_WEB_UI=transmission-web-control
       - TRANSMISSION_DOWNLOAD_DIR=/data/torrents

--- a/roles/hmsdocker/templates/docker-compose.yml.j2
+++ b/roles/hmsdocker/templates/docker-compose.yml.j2
@@ -452,6 +452,9 @@ services:
       - '{{ transmission_dns_2 }}'
     volumes:
       - ${HMSD_APPS_PATH}/transmission/config:/data/transmission-home
+    {% if transmission_ovpn_config_local_path != "" and transmission_vpn_provider == "custom" %}
+      - ${VPN_CONFIG_LOCAL_PATH}:/etc/openvpn/custom
+    {% endif %}
     {% if transmission_use_nas_enabled %}
       - {{ hms_docker_mount_path }}/apps/transmission/torrents:/data/torrents
     {% elif transmission_custom_download_path_enabled %}
@@ -471,10 +474,10 @@ services:
       - OPENVPN_PROVIDER=${VPN_PROVIDER}
       - OPENVPN_USERNAME=${VPN_USER}
       - OPENVPN_PASSWORD=${VPN_PASS}
-      {% if transmission_github_config_source_repo != "" %}
+      {% if transmission_ovpn_config_source_repo != "" %}
       - GITHUB_CONFIG_SOURCE_REPO=${VPN_REPO}
       {% endif %}
-      {% if transmission_ovpn_config != "" %}
+      {% if transmission_ovpn_config_file != "" %}
       - OPENVPN_CONFIG=${VPN_CONFIG}
       {% endif %}
       - OPENVPN_OPTS=--inactive 3600 --ping 10 --ping-exit 60

--- a/roles/hmsdocker/templates/docker-compose.yml.j2
+++ b/roles/hmsdocker/templates/docker-compose.yml.j2
@@ -471,6 +471,8 @@ services:
       - OPENVPN_PROVIDER=${VPN_PROVIDER}
       - OPENVPN_USERNAME=${VPN_USER}
       - OPENVPN_PASSWORD=${VPN_PASS}
+      - GITHUB_CONFIG_SOURCE_REPO=${VPN_REPO}
+      - OPENVPN_CONFIG=${VPN_CONFIG}
       - OPENVPN_OPTS=--inactive 3600 --ping 10 --ping-exit 60
       - TRANSMISSION_WEB_UI=transmission-web-control
       - TRANSMISSION_DOWNLOAD_DIR=/data/torrents

--- a/roles/hmsdocker/templates/env.j2
+++ b/roles/hmsdocker/templates/env.j2
@@ -25,8 +25,12 @@ PLEX_CERT_RESTART={{ hms_docker_plex_ssl_restart_plex }}
 VPN_PROVIDER={{ transmission_vpn_provider }}
 VPN_USER={{ transmission_vpn_user }}
 VPN_PASS={{ transmission_vpn_pass }}
+{% if transmission_github_config_source_repo != "" %}
 VPN_REPO={{ transmission_github_config_source_repo }}
+{% endif %}
+{% if transmission_ovpn_config != "" %}
 VPN_CONFIG={{ transmission_ovpn_config }}
+{% endif %}
 {% endif %}
 ### END VPN
 

--- a/roles/hmsdocker/templates/env.j2
+++ b/roles/hmsdocker/templates/env.j2
@@ -25,6 +25,8 @@ PLEX_CERT_RESTART={{ hms_docker_plex_ssl_restart_plex }}
 VPN_PROVIDER={{ transmission_vpn_provider }}
 VPN_USER={{ transmission_vpn_user }}
 VPN_PASS={{ transmission_vpn_pass }}
+VPN_REPO={{ transmission_github_config_source_repo }}
+VPN_CONFIG={{ transmission_ovpn_config }}
 {% endif %}
 ### END VPN
 

--- a/roles/hmsdocker/templates/env.j2
+++ b/roles/hmsdocker/templates/env.j2
@@ -25,11 +25,14 @@ PLEX_CERT_RESTART={{ hms_docker_plex_ssl_restart_plex }}
 VPN_PROVIDER={{ transmission_vpn_provider }}
 VPN_USER={{ transmission_vpn_user }}
 VPN_PASS={{ transmission_vpn_pass }}
-{% if transmission_github_config_source_repo != "" %}
-VPN_REPO={{ transmission_github_config_source_repo }}
+{% if transmission_ovpn_config_source_repo != "" %}
+VPN_REPO={{ transmission_ovpn_config_source_repo }}
 {% endif %}
-{% if transmission_ovpn_config != "" %}
-VPN_CONFIG={{ transmission_ovpn_config }}
+{% if transmission_ovpn_config_file != "" %}
+VPN_CONFIG={{ transmission_ovpn_config_file }}
+{% endif %}
+{% if transmission_ovpn_config_local_path != "" and transmission_vpn_provider == "custom" %}
+VPN_CONFIG_LOCAL_PATH={{ transmission_ovpn_config_local_path }}
 {% endif %}
 {% endif %}
 ### END VPN

--- a/vars/default/transmission.yml
+++ b/vars/default/transmission.yml
@@ -5,7 +5,11 @@ transmission_vpn_provider: ""
 transmission_vpn_user: ""
 transmission_vpn_pass: ""
 
-# Transmissoin seed ratio settings
+# Use custom ovpn files https://github.com/haugene/vpn-configs-contrib/blob/main/CONTRIBUTING.md
+transmission_github_config_source_repo: ""
+transmission_ovpn_config: ""
+
+# Transmission seed ratio settings
 transmission_ratio_limit: "1" # default: "1"
 transmission_ratio_enabled: "true" # default: "true"
 

--- a/vars/default/transmission.yml
+++ b/vars/default/transmission.yml
@@ -5,10 +5,6 @@ transmission_vpn_provider: ""
 transmission_vpn_user: ""
 transmission_vpn_pass: ""
 
-# Use custom ovpn files https://github.com/haugene/vpn-configs-contrib/blob/main/CONTRIBUTING.md
-transmission_github_config_source_repo: ""
-transmission_ovpn_config: ""
-
 # Transmission seed ratio settings
 transmission_ratio_limit: "1" # default: "1"
 transmission_ratio_enabled: "true" # default: "true"
@@ -16,3 +12,13 @@ transmission_ratio_enabled: "true" # default: "true"
 # DNS servers to use for the transmission container
 transmission_dns_1: "8.8.8.8"
 transmission_dns_2: "8.8.4.4"
+
+## External Providers and Custom VPN Options
+# These are for changing the VPN config to a different server or type for example
+# For help with these variables, see the docs located in `docs/Transmission.md`
+
+# default: ""
+transmission_ovpn_config_file: ""
+
+# default: ""
+transmission_ovpn_config_local_path: ""


### PR DESCRIPTION
As per the guide here: https://github.com/haugene/vpn-configs-contrib/blob/main/CONTRIBUTING.md you can supply a few additional variables and have the ability to use your own VPN config as opposed to a supported provider.

I have tested Windscribe and as I'm not able to select a profile, it defaults to a country the other side of the world... making downloads very slow. Adding these attributes will allow me to select a closer location.