### PR TITLE
Remove pip dependency

### DIFF
--- a/.github/workflows/run-playbook.yml
+++ b/.github/workflows/run-playbook.yml
@@ -41,5 +41,5 @@ jobs:
       - name: Check containers
         run: |
           sleep 60
-          sudo pip3 install python-dotenv
+          sudo pip3 install -r .github/workflows/scripts/requirements.txt
           sudo make verify-containers

--- a/.github/workflows/scripts/requirements.txt
+++ b/.github/workflows/scripts/requirements.txt
@@ -1,0 +1,7 @@
+certifi==2024.2.2
+charset-normalizer==3.3.2
+docker==7.1.0
+idna==3.7
+python-dotenv==1.0.1
+requests==2.32.2
+urllib3==2.2.1

--- a/hms-docker.yml
+++ b/hms-docker.yml
@@ -5,12 +5,9 @@
   vars:
     regex: '[^A-Za-z0-9._-]'
     replace: '_'
-    pip_install_packages:
-    - name: docker
 
   roles:
     - galaxy-roles/geerlingguy.docker
-    - galaxy-roles/geerlingguy.pip
 
   tasks:
   - name: Ensure vars are loaded


### PR DESCRIPTION
Removes final pip dependency that installs the `docker` package.

Removal of this package should also allow Ubuntu 24.04 to work normally now since it won't yell about an externally managed environment.