### PR TITLE
Inventory migration

### DIFF
--- a/.github/workflows/run-playbook.yml
+++ b/.github/workflows/run-playbook.yml
@@ -23,8 +23,12 @@ jobs:
           sudo apt install ansible
 
       - name: Ensure base playbook requirements
+        # should mirror the steps for advanced config creation
+        # does not use the `make` command since it requires input and we cannot input in a Runner
         run: |
-          make basic
+          mkdir -p ./inventory/group_vars/all
+          cp ./roles/hmsdocker/defaults/main/*.yml ./inventory/group_vars/all
+          chmod 0600 ./inventory/group_vars/all/*.yml
           make install-reqs
 
       - name: Run playbook

--- a/.github/workflows/run-playbook.yml
+++ b/.github/workflows/run-playbook.yml
@@ -24,10 +24,8 @@ jobs:
 
       - name: Ensure base playbook requirements
         run: |
-          mkdir -p ./vars/custom
-          cp vars/default/*.yml ./vars/custom
-          mv ./vars/custom/main.yml ./vars/custom/main_custom.yml
-          sudo make install-reqs
+          make basic
+          make install-reqs
 
       - name: Run playbook
         run: >-

--- a/.github/workflows/run-playbook.yml
+++ b/.github/workflows/run-playbook.yml
@@ -32,8 +32,7 @@ jobs:
       - name: Run playbook
         run: >-
           sudo ansible-playbook
-          -i inventory
-          --connection local
+          -i inventory/hosts.yml
           hms-docker.yml
           --diff
           --extra-vars "@.github/extra-vars.yml"

--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,9 @@
 __pycache__/
 
 galaxy-roles/
-vars/custom.yml
-vars/custom/*
-!vars/custom/main.yml
+vars/custom*
+inventory/group_vars/all/*
+inventory/hosts-custom.yml
 
 # others to ignore
 *.log

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ update:
 migrate-vars:
 	
 	@if [ -d $(PREV_CUSTOM_CONF_DIR) ] && [ ! -L $(PREV_CUSTOM_CONF_DIR) ]; then\
+		mkdir -p $(CUSTOM_CONF_DIR);\
 		cp $(PREV_CUSTOM_CONF_DIR)/* $(CUSTOM_CONF_DIR);\
 		rm -rf $(PREV_CUSTOM_CONF_DIR);\
 		ln -s $(BASEDIR)/$(CUSTOM_CONF_DIR) $(BASEDIR)/$(PREV_CUSTOM_CONF_DIR);\

--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,8 @@ update:
 	@sed -i 's\traefik_ext_hosts_configs_path\hmsdocker_traefik_static_config_location\g' $(CUSTOM_CONF_DIR)/traefik.yml
 	@echo Update finished
 
-# Used for after the migration from the `vars/custom` directory to the correct `inventory/group_vars/all` directory
+# Used for the migration from the `vars/custom` directory to the correct `inventory/group_vars/all` directory
 migrate-vars:
-	
 	@if [ -d $(PREV_CUSTOM_CONF_DIR) ] && [ ! -L $(PREV_CUSTOM_CONF_DIR) ]; then\
 		mkdir -p $(CUSTOM_CONF_DIR);\
 		cp $(PREV_CUSTOM_CONF_DIR)/* $(CUSTOM_CONF_DIR);\

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,11 @@ SHELL := /bin/bash
 DEFAULT_CONFS = vars/default/*.yml
 ADVANCED_CONFS = roles/hmsdocker/defaults/main/*.yml
 
-CUSTOM_CONF_DIR = ./vars/custom
+BASEDIR=$(shell pwd)
+
+CUSTOM_CONF_DIR = inventory/group_vars/all
+
+PREV_CUSTOM_CONF_DIR = vars/custom
 
 # Found and modified from: https://gist.github.com/Pierstoval/b2539c387c467c017bf2b0ace5a2e79b
 # To use the "confirm" target inside another target,
@@ -43,10 +47,10 @@ advanced:
 	fi
 
 check: install-reqs
-	@ansible-playbook -i inventory --connection local hms-docker.yml --diff --check
+	@ansible-playbook -i inventory/hosts.yml hms-docker.yml --diff --check
 
 apply: install-reqs
-	@ansible-playbook -i inventory --connection local hms-docker.yml --diff
+	@ansible-playbook -i inventory/hosts.yml hms-docker.yml --diff
 
 install-reqs:
 	@ansible-galaxy install -r galaxy-requirements.yml -p ./galaxy-roles
@@ -61,6 +65,20 @@ update:
 	@sed -i 's\traefik_ext_hosts_configs_path\hmsdocker_traefik_static_config_location\g' $(CUSTOM_CONF_DIR)/traefik.yml
 	@echo Update finished
 
+# Used for after the migration from the `vars/custom` directory to the correct `inventory/group_vars/all` directory
+migrate-vars:
+	
+	@if [ -d $(PREV_CUSTOM_CONF_DIR) ] && [ ! -L $(PREV_CUSTOM_CONF_DIR) ]; then\
+		cp $(PREV_CUSTOM_CONF_DIR)/* $(CUSTOM_CONF_DIR);\
+		rm -rf $(PREV_CUSTOM_CONF_DIR);\
+		ln -s $(BASEDIR)/$(CUSTOM_CONF_DIR) $(BASEDIR)/$(PREV_CUSTOM_CONF_DIR);\
+		echo Moved files and created symlink from $(PREV_CUSTOM_CONF_DIR) to $(CUSTOM_CONF_DIR);\
+	elif [ -d $(PREV_CUSTOM_CONF_DIR) ] && [ -L $(PREV_CUSTOM_CONF_DIR) ]; then\
+		echo "Already migrated";\
+	else\
+		echo "Previous variables directory does not exist at location: $(PREV_CUSTOM_CONF_DIR)";\
+	fi
+	
 help:
 	@echo make basic :: setup a basic config
 	@echo make advanced :: setup an advanced config

--- a/galaxy-requirements.yml
+++ b/galaxy-requirements.yml
@@ -1,2 +1,1 @@
 - src: geerlingguy.docker
-- src: geerlingguy.pip

--- a/hms-docker.yml
+++ b/hms-docker.yml
@@ -10,10 +10,6 @@
     - galaxy-roles/geerlingguy.docker
 
   tasks:
-  - name: Ensure vars are loaded
-    ansible.builtin.include_vars:
-      dir: vars/custom
-
   - name: Ensure Nvidia GPU role if enabled
     ansible.builtin.import_role:
       name: gpu

--- a/hms-docker.yml
+++ b/hms-docker.yml
@@ -10,6 +10,17 @@
     - galaxy-roles/geerlingguy.docker
 
   tasks:
+  - name: Check if old variables dir exists
+    ansible.builtin.stat:
+      path: vars/custom
+    register: prev_var_dir
+
+  - name: Fail if previous var dir exists and is not symlink
+    ansible.builtin.fail:
+      msg: "You are using the old directory structure for variables. Please update your paths by running: 'make migrate-vars'. This will move the 'vars/custom' files to 'inventory/group_vars/all'"
+    when:
+      - prev_var_dir.stat.exists and not prev_var_dir.stat.islnk
+
   - name: Ensure Nvidia GPU role if enabled
     ansible.builtin.import_role:
       name: gpu

--- a/inventory
+++ b/inventory
@@ -1,1 +1,0 @@
-localhost

--- a/inventory/hosts.yml
+++ b/inventory/hosts.yml
@@ -1,0 +1,5 @@
+all:
+  hosts:
+    localhost:
+      ansible_connection: local
+

--- a/roles/hmsdocker/tasks/scripts.yml
+++ b/roles/hmsdocker/tasks/scripts.yml
@@ -23,7 +23,7 @@
     - name: Ensure env symlink
       ansible.builtin.file:
         state: link
-        src: "{{ compose_env.dest }}"
+        src: "{{ compose_env.dest | default(hms_docker_data_path + '/.env') }}"
         dest: "{{ monitoring_scripts_path.path }}/.env"
 
     - name: Ensure monitoring scripts


### PR DESCRIPTION
This moves variables from the `vars/custom` directory to the (hopefully) more correct `inventory/group_vars/all` directory.

This also requires the `inventory` file be recreated in yml format (personal preference) in `inventory/hosts.yml`.

This PR will add the following features:
* Ability to scale to multiple hosts since you will now be able to specify host-level variables in a custom inventory file
* Remove the need for the `--connection local` argument in the `Makefile` since the connection is now handled in the inventory file
* Additional `make migrate-vars` command to automatically copy the previous variable files to the new `inventory/group_vars/all` directory and create a symlink from `vars/custom` to point to the new location so the old directory will still work for now
* Removes unnecessary variable include task in the playbook since group_vars are auto-loaded
* Also adds sane-default for a variable used when deploying the custom monitoring scripts since this would usually error out in `check_mode`