### PR TITLE
Add parsing for app API keys

### DIFF
--- a/.github/extra-vars.yml
+++ b/.github/extra-vars.yml
@@ -141,7 +141,7 @@
       "homepage_stats": true
     },
     "sabnzbd": {
-      "enabled": false,
+      "enabled": true,
       "proxy_host_rule": sabnzbd,
       "directory": true,
       "traefik": true,
@@ -152,7 +152,7 @@
       "homepage_stats": true
     },
     "authentik": {
-      "enabled": false,
+      "enabled": true,
       "proxy_host_rule": "authentik",
       "directory": true,
       "traefik": true,

--- a/.github/workflows/run-playbook.yml
+++ b/.github/workflows/run-playbook.yml
@@ -44,3 +44,11 @@ jobs:
           sleep 60
           sudo pip3 install -r .github/workflows/scripts/requirements.txt
           sudo make verify-containers
+
+      - name: Run playbook again to ensure API keys are retrieved
+        run: >-
+          sudo ansible-playbook
+          -i inventory/hosts.yml
+          hms-docker.yml
+          --diff
+          --extra-vars "@.github/extra-vars.yml"

--- a/hms-docker.yml
+++ b/hms-docker.yml
@@ -5,6 +5,8 @@
   vars:
     regex: '[^A-Za-z0-9._-]'
     replace: '_'
+    arr_apikey: '(?<=\<ApiKey\>)\w*(?=\<\/ApiKey\>)'
+    
 
   roles:
     - galaxy-roles/geerlingguy.docker

--- a/roles/hmsdocker/defaults/main/homepage_api_keys.yml
+++ b/roles/hmsdocker/defaults/main/homepage_api_keys.yml
@@ -1,38 +1,13 @@
-# Sonarr
-homepage_sonarr_key: 
-homepage_sonarr_4k_key: 
-
-# Radarr
-homepage_radarr_key: 
-homepage_radarr_4k_key: 
-
-# Prowlarr
-homepage_prowlarr_key: 
+# Other keys not listed here may be retrieved during a playbook run from the apps config file
 
 # NZB
-homepage_sabnzbd_key: 
 homepage_nzbget_key: 
-
-# Tautulli
-homepage_tautulli_key: 
-
-# Plex
-homepage_plex_key: 
-
-# Overseerr
-homepage_overseerr_key: 
-
-# Bazarr
-homepage_bazarr_key: 
 
 # Authentik
 homepage_authentik_key: 
 
 # Portainer
 homepage_portainer_key: 
-
-# Readarr
-homepage_readarr_key: 
 
 # Jellyfin
 homepage_jellyfin_key: 

--- a/roles/hmsdocker/tasks/app_api_key_reader.yml
+++ b/roles/hmsdocker/tasks/app_api_key_reader.yml
@@ -27,11 +27,16 @@
 - name: Handle Radarr configs
   when: hmsdocker_container_enabled_radarr
   block:
+    - name: Check for Radarr config file
+      ansible.builtin.stat:
+        path: "{{ hms_docker_apps_path }}/radarr/config/config.xml"
+      register: radarr_conf_path
+
     - name: Slurp Radarr key data
       ansible.builtin.slurp:
-        src: "{{ hms_docker_apps_path }}/radarr/config/config.xml"
+        src: "{{ radarr_conf_path.stat.path }}"
       register: slurped_api_key_radarr
-      when: hmsdocker_container_enabled_radarr
+      when: radarr_conf_path.stat.exists
 
     - name: Check for Radarr 4K config file
       ansible.builtin.stat:

--- a/roles/hmsdocker/tasks/app_api_key_reader.yml
+++ b/roles/hmsdocker/tasks/app_api_key_reader.yml
@@ -1,0 +1,146 @@
+- name: Handle Sonarr configs
+  when: hmsdocker_container_enabled_sonarr
+  block:
+    - name: Check for Sonarr config file
+      ansible.builtin.stat:
+        path: "{{ hms_docker_apps_path }}/sonarr/config/config.xml"
+      register: sonarr_conf_path
+
+    - name: Slurp Sonarr key data
+      ansible.builtin.slurp:
+        src: "{{ sonarr_conf_path.stat.path }}"
+      register: slurped_api_key_sonarr
+      when: 
+        - sonarr_conf_path.stat.exists
+
+    - name: Check for Sonarr 4K config file
+      ansible.builtin.stat:
+        path: "{{ hms_docker_apps_path }}/sonarr-{{ separate_4k_instances_suffix }}/config/config.xml"
+      register: sonarr_4k_conf_path
+
+    - name: Slurp Sonarr 4K key data
+      ansible.builtin.slurp:
+        src: "{{ sonarr_4k_conf_path.stat.path }}"
+      register: slurped_api_key_sonarr_4k
+      when: separate_4k_instances_enable and sonarr_4k_conf_path.stat.exists
+
+- name: Handle Radarr configs
+  when: hmsdocker_container_enabled_radarr
+  block:
+    - name: Slurp Radarr key data
+      ansible.builtin.slurp:
+        src: "{{ hms_docker_apps_path }}/radarr/config/config.xml"
+      register: slurped_api_key_radarr
+      when: hmsdocker_container_enabled_radarr
+
+    - name: Check for Radarr 4K config file
+      ansible.builtin.stat:
+        path: "{{ hms_docker_apps_path }}/radarr-{{ separate_4k_instances_suffix }}/config/config.xml"
+      register: radarr_4k_conf_path
+
+    - name: Slurp Radarr 4K key data
+      ansible.builtin.slurp:
+        src: "{{ radarr_4k_conf_path.stat.path }}"
+      register: slurped_api_key_radarr_4k
+      when: 
+        - separate_4k_instances_enable
+        - radarr_4k_conf_path.stat.exists
+
+- name: Handle Readarr config
+  when: hmsdocker_container_enabled_readarr
+  block:
+    - name: Check for Readarr config file
+      ansible.builtin.stat:
+        path: "{{ hms_docker_apps_path }}/readarr/config/config.xml"
+      register: readarr_conf_path
+
+    - name: Slurp Readarr key data
+      ansible.builtin.slurp:
+        src: "{{ readarr_conf_path.stat.path }}"
+      register: slurped_api_key_readarr
+      when: readarr_conf_path.stat.exists
+
+- name: Handle Prowlarr config
+  when: hmsdocker_container_enabled_prowlarr
+  block:
+    - name: Check for Prowlarr config file
+      ansible.builtin.stat:
+        path: "{{ hms_docker_apps_path }}/prowlarr/config/config.xml"
+      register: prowlarr_conf_path
+
+    - name: Slurp Prowlarr key data
+      ansible.builtin.slurp:
+        src: "{{ prowlarr_conf_path.stat.path }}"
+      register: slurped_api_key_prowlarr
+      when: prowlarr_conf_path.stat.exists
+
+- name: Handle Bazarr config
+  when: hmsdocker_container_enabled_bazarr
+  block:
+    - name: Check for Bazarr config file
+      ansible.builtin.stat:
+        path: "{{ hms_docker_apps_path }}/bazarr/config/config/config.yaml"
+      register: bazarr_conf_path
+
+    - name: Slurp Bazarr key data
+      ansible.builtin.slurp:
+        src: "{{ bazarr_conf_path.stat.path }}"
+      register: slurped_api_key_bazarr
+      when: bazarr_conf_path.stat.exists
+
+- name: Handle Overseerr config
+  when: hmsdocker_container_enabled_overseerr
+  block:
+    - name: Check for Overseerr config file
+      ansible.builtin.stat:
+        path: "{{ hms_docker_apps_path }}/overseerr/config/settings.json"
+      register: overseerr_conf_path
+
+    - name: Slurp Overseerr key data
+      ansible.builtin.slurp:
+        src: "{{ overseerr_conf_path.stat.path }}"
+      register: slurped_api_key_overseerr
+      when: overseerr_conf_path.stat.exists
+
+- name: Handle Tautulli config
+  when: hmsdocker_container_enabled_tautulli
+  block:
+    - name: Check for Tautulli config file
+      ansible.builtin.stat:
+        path: "{{ hms_docker_apps_path }}/tautulli/config/config.ini"
+      register: tautulli_conf_path
+
+    - name: Slurp Tautulli key data
+      ansible.builtin.slurp:
+        src: "{{ tautulli_conf_path.stat.path }}"
+      register: slurped_api_key_tautulli
+      when: tautulli_conf_path.stat.exists
+
+- name: Handle Sabnzbd config
+  when: hmsdocker_container_enabled_sabnzbd
+  block:
+    - name: Check for Sabnzbd config file
+      ansible.builtin.stat:
+        path: "{{ hms_docker_apps_path }}/sabnzbd/config/sabnzbd.ini"
+      register: sabnzbd_conf_path
+
+    - name: Slurp Sabnzbd key data
+      ansible.builtin.slurp:
+        src: "{{ sabnzbd_conf_path.stat.path }}"
+      register: slurped_api_key_sabnzbd
+      when: sabnzbd_conf_path.stat.exists
+
+- name: Handle Plex config file
+  when: hmsdocker_container_enabled_plex
+  block:
+    - name: Check for Plex config file
+      ansible.builtin.stat:
+        path: "{{ hms_docker_apps_path }}/plex/config/Library/Application Support/Plex Media Server/Preferences.xml"
+      register: plex_conf_path
+
+    - name: Slurp Plex key data
+      ansible.builtin.slurp:
+        src: "{{ plex_conf_path.stat.path }}"
+      register: slurped_api_key_plex
+      when:
+        - plex_conf_path.stat.exists

--- a/roles/hmsdocker/tasks/authentik.yml
+++ b/roles/hmsdocker/tasks/authentik.yml
@@ -1,38 +1,4 @@
 ---
-### BEGIN Process required for migrating old Authentik-specific env to current
-- name: Check for existing .env file
-  ansible.builtin.stat:
-    path: "{{ hms_docker_data_path }}/.env"
-  register: env_file_path
-
-- name: Check for existing authentik key file
-  ansible.builtin.stat:
-    path: "{{ authentik_key_path }}"
-  register: authentik_key_precheck
-
-- name: Check for existing authentik postgres password file
-  ansible.builtin.stat:
-    path: "{{ authentik_pgpass_path }}"
-  register: authentik_pg_pass_precheck
-
-- name: Slurp existing authentik secret key data
-  ansible.builtin.slurp:
-    path: "{{ env_file_path.stat.path }}"
-  register: slurped_old_authentik_data
-  no_log: true
-  when: env_file_path.stat.exists and not authentik_pg_pass_precheck.stat.exists and not authentik_key_precheck.stat.exists
-
-- name: Pull authentik items from previous install
-  ansible.builtin.set_fact:
-    authentik_old_key: "{{ slurped_old_authentik_data['content'] | b64decode | regex_search('(?<=AUTHENTIK_SECRET_KEY=).*') }}"
-    authentik_old_pg_user: "{{ slurped_old_authentik_data['content'] | b64decode | regex_search('(?<=PG_USER=).*') }}"
-    authentik_old_pg_pass: "{{ slurped_old_authentik_data['content'] | b64decode | regex_search('(?<=PG_PASS=).*') }}"
-    authentik_old_pg_db: "{{ slurped_old_authentik_data['content'] | b64decode | regex_search('(?<=PG_DB=).*') }}"
-    cacheable: false
-  when: slurped_old_authentik_data['content'] is defined
-  no_log: true
-### END Upgrade process for Authentik env file
-
 - name: Ensure authentik secret key file
   ansible.builtin.template:
     src: authentik_secret.j2
@@ -45,7 +11,7 @@
   register: authentik_key_template_output
   no_log: true
   vars:
-    key: "{{ authentik_old_key | default(lookup('password', '/dev/null length=50 chars=ascii_letters')) }}"
+    key: "{{ lookup('ansible.builtin.password', '/dev/null', chars=['ascii_letters', 'digits'], length=50) }}"
 
 - name: Ensure authentik postgres password file
   ansible.builtin.template:
@@ -59,7 +25,7 @@
   register: authentik_pgpass_template_output
   no_log: true
   vars:
-    key: "{{ authentik_old_pg_pass | default(lookup('password', '/dev/null length=50 chars=ascii_letters')) }}"
+    key: "{{ lookup('ansible.builtin.password', '/dev/null', chars=['ascii_letters', 'digits'], length=50) }}"
 
 - name: Slurp authentik secret key data
   ansible.builtin.slurp:

--- a/roles/hmsdocker/tasks/homepage.yml
+++ b/roles/hmsdocker/tasks/homepage.yml
@@ -20,6 +20,40 @@
   when: watchtower_key_output.dest is defined
   no_log: true
 
+- name: Slurp Sonarr key data
+  ansible.builtin.slurp:
+    src: "{{ hms_docker_apps_path }}/sonarr/config/config.xml"
+  register: sonarr_api_key
+  check_mode: false
+  when: hmsdocker_container_enabled_sonarr
+
+- name: Slurp Sonarr 4K key data
+  ansible.builtin.slurp:
+    src: "{{ hms_docker_apps_path }}/sonarr-{{ separate_4k_instances_suffix }}/config/config.xml"
+  register: sonarr_4k_api_key
+  check_mode: false
+  when: hmsdocker_container_enabled_sonarr and separate_4k_instances_enable
+
+- name: Slurp Radarr key data
+  ansible.builtin.slurp:
+    src: "{{ hms_docker_apps_path }}/radarr/config/config.xml"
+  register: radarr_api_key
+  check_mode: false
+  when: hmsdocker_container_enabled_radarr
+
+- name: Slurp Radarr 4K key data
+  ansible.builtin.slurp:
+    src: "{{ hms_docker_apps_path }}/radarr-{{ separate_4k_instances_suffix }}/config/config.xml"
+  register: radarr_4k_api_key
+  check_mode: false
+  when: hmsdocker_container_enabled_radarr and separate_4k_instances_enable
+
+- name: Slurp Prowlarr key data
+  ansible.builtin.slurp:
+    src: "{{ hms_docker_apps_path }}/prowlarr/config/config.xml"
+  register: prowlarr_api_key
+  check_mode: false
+  when: hmsdocker_container_enabled_prowlarr
 - name: Ensure homepage docker config
   ansible.builtin.copy:
     src: homepage_docker.yaml

--- a/roles/hmsdocker/tasks/homepage.yml
+++ b/roles/hmsdocker/tasks/homepage.yml
@@ -58,6 +58,8 @@
   register: prowlarr_api_key
   check_mode: false
   when: hmsdocker_container_enabled_prowlarr
+  ignore_errors: true
+
 - name: Ensure homepage docker config
   ansible.builtin.copy:
     src: homepage_docker.yaml

--- a/roles/hmsdocker/tasks/homepage.yml
+++ b/roles/hmsdocker/tasks/homepage.yml
@@ -20,46 +20,6 @@
   when: watchtower_key_output.dest is defined
   no_log: true
 
-- name: Slurp Sonarr key data
-  ansible.builtin.slurp:
-    src: "{{ hms_docker_apps_path }}/sonarr/config/config.xml"
-  register: sonarr_api_key
-  check_mode: false
-  when: hmsdocker_container_enabled_sonarr
-  ignore_errors: true
-
-- name: Slurp Sonarr 4K key data
-  ansible.builtin.slurp:
-    src: "{{ hms_docker_apps_path }}/sonarr-{{ separate_4k_instances_suffix }}/config/config.xml"
-  register: sonarr_4k_api_key
-  check_mode: false
-  when: hmsdocker_container_enabled_sonarr and separate_4k_instances_enable
-  ignore_errors: true
-
-- name: Slurp Radarr key data
-  ansible.builtin.slurp:
-    src: "{{ hms_docker_apps_path }}/radarr/config/config.xml"
-  register: radarr_api_key
-  check_mode: false
-  when: hmsdocker_container_enabled_radarr
-  ignore_errors: true
-
-- name: Slurp Radarr 4K key data
-  ansible.builtin.slurp:
-    src: "{{ hms_docker_apps_path }}/radarr-{{ separate_4k_instances_suffix }}/config/config.xml"
-  register: radarr_4k_api_key
-  check_mode: false
-  when: hmsdocker_container_enabled_radarr and separate_4k_instances_enable
-  ignore_errors: true
-
-- name: Slurp Prowlarr key data
-  ansible.builtin.slurp:
-    src: "{{ hms_docker_apps_path }}/prowlarr/config/config.xml"
-  register: prowlarr_api_key
-  check_mode: false
-  when: hmsdocker_container_enabled_prowlarr
-  ignore_errors: true
-
 - name: Ensure homepage docker config
   ansible.builtin.copy:
     src: homepage_docker.yaml

--- a/roles/hmsdocker/tasks/homepage.yml
+++ b/roles/hmsdocker/tasks/homepage.yml
@@ -26,6 +26,7 @@
   register: sonarr_api_key
   check_mode: false
   when: hmsdocker_container_enabled_sonarr
+  ignore_errors: true
 
 - name: Slurp Sonarr 4K key data
   ansible.builtin.slurp:
@@ -33,6 +34,7 @@
   register: sonarr_4k_api_key
   check_mode: false
   when: hmsdocker_container_enabled_sonarr and separate_4k_instances_enable
+  ignore_errors: true
 
 - name: Slurp Radarr key data
   ansible.builtin.slurp:
@@ -40,6 +42,7 @@
   register: radarr_api_key
   check_mode: false
   when: hmsdocker_container_enabled_radarr
+  ignore_errors: true
 
 - name: Slurp Radarr 4K key data
   ansible.builtin.slurp:
@@ -47,6 +50,7 @@
   register: radarr_4k_api_key
   check_mode: false
   when: hmsdocker_container_enabled_radarr and separate_4k_instances_enable
+  ignore_errors: true
 
 - name: Slurp Prowlarr key data
   ansible.builtin.slurp:

--- a/roles/hmsdocker/tasks/main.yml
+++ b/roles/hmsdocker/tasks/main.yml
@@ -117,6 +117,10 @@
     authentik_pgu: "{{ authentik_old_pg_user if authentik_old_pg_user is defined and authentik_old_pg_user != '' else authentik_pg_user }}"
     authentik_pgdb: "{{ authentik_old_pg_db if authentik_old_pg_db is defined and authentik_old_pg_db != '' else authentik_pg_db }}"
     watchtower_key: "{{ (slurped_watchtower_key_data['content'] | b64decode) if slurped_watchtower_key_data['content'] is defined else '### Will be obtained during full run ###' }}"
+    sonarr_key: "{{ sonarr_api_key['content'] | b64decode | regex_search(arr_apikey)| default('') }}"
+    sonarr_4k_key: "{{ sonarr_4k_api_key['content'] | b64decode | regex_search(arr_apikey)| default('') }}"
+    radarr_key: "{{ radarr_api_key['content'] | b64decode | regex_search(arr_apikey)| default('') }}"
+    radarr_4k_key: "{{ radarr_4k_api_key['content'] | b64decode | regex_search(arr_apikey)| default('') }}"
 
 - name: Ensure docker-compose.yml file.
   ansible.builtin.template:

--- a/roles/hmsdocker/tasks/main.yml
+++ b/roles/hmsdocker/tasks/main.yml
@@ -98,6 +98,9 @@
       diff: false
       changed_when: false
   
+- name: Retrieve app API keys if available
+  ansible.builtin.import_tasks: "app_api_key_reader.yml"
+  when: hmsdocker_container_enabled_homepage
 
 - name: Ensure env
   ansible.builtin.template:
@@ -117,10 +120,17 @@
     authentik_pgu: "{{ authentik_old_pg_user if authentik_old_pg_user is defined and authentik_old_pg_user != '' else authentik_pg_user }}"
     authentik_pgdb: "{{ authentik_old_pg_db if authentik_old_pg_db is defined and authentik_old_pg_db != '' else authentik_pg_db }}"
     watchtower_key: "{{ (slurped_watchtower_key_data['content'] | b64decode) if slurped_watchtower_key_data['content'] is defined else '### Will be obtained during full run ###' }}"
-    sonarr_key: "{{ sonarr_api_key['content'] | b64decode | regex_search(arr_apikey)| default('') }}"
-    sonarr_4k_key: "{{ sonarr_4k_api_key['content'] | b64decode | regex_search(arr_apikey)| default('') }}"
-    radarr_key: "{{ radarr_api_key['content'] | b64decode | regex_search(arr_apikey)| default('') }}"
-    radarr_4k_key: "{{ radarr_4k_api_key['content'] | b64decode | regex_search(arr_apikey)| default('') }}"
+    sonarr_key: "{{ slurped_api_key_sonarr['content'] | b64decode | regex_search(arr_apikey) | default('') }}"
+    sonarr_4k_key: "{{ slurped_api_key_sonarr_4k['content'] | b64decode | regex_search(arr_apikey) | default('') }}"
+    radarr_key: "{{ slurped_api_key_radarr['content'] | b64decode | regex_search(arr_apikey) | default('') }}"
+    radarr_4k_key: "{{ slurped_api_key_radarr_4k['content'] | b64decode | regex_search(arr_apikey) | default('') }}"
+    prowlarr_key: "{{ slurped_api_key_prowlarr['content'] | b64decode | regex_search(arr_apikey) | default('') }}"
+    bazarr_key: "{{ slurped_api_key_bazarr['content'] | b64decode | from_yaml }}"
+    overseerr_key: "{{ slurped_api_key_overseerr['content'] | b64decode | from_json }}"
+    tautulli_key: "{{ slurped_api_key_tautulli['content'] | b64decode | regex_search('(?<=api_key = )\\w*') | default('') }}"
+    plex_key: "{{ slurped_api_key_plex['content'] | b64decode | regex_search('(?<=PlexOnlineToken=\")(.*?)(?=\")') | default('') }}"
+    sabnzbd_key: "{{ slurped_api_key_sabnzbd['content'] | b64decode | regex_search('(?<=api_key = )\\w*') | default('') }}"
+    readarr_key: "{{ slurped_api_key_readarr['content'] | b64decode | regex_search(arr_apikey) | default('') }}"
 
 - name: Ensure docker-compose.yml file.
   ansible.builtin.template:

--- a/roles/hmsdocker/tasks/sabnzbd.yml
+++ b/roles/hmsdocker/tasks/sabnzbd.yml
@@ -38,5 +38,5 @@
         path: "{{ sabnzbd_config_path.stat.path }}"
         regexp: '(?<=host_whitelist = ).*'
         replace: "{{ slurped_sabnzbd_hostlist | join(',') }}{{ hms_docker_container_map['sabnzbd']['proxy_host_rule'] }}.{{ hms_docker_domain }}"
-      when: hms_docker_container_map['sabnzbd']['proxy_host_rule'] + "." + hms_docker_domain not in slurped_sabnzbd_hostlist
+      when: (hms_docker_container_map['sabnzbd']['proxy_host_rule'] + "." + hms_docker_domain) not in slurped_sabnzbd_hostlist
       notify: restart sabnzbd

--- a/roles/hmsdocker/templates/env.j2
+++ b/roles/hmsdocker/templates/env.j2
@@ -57,9 +57,9 @@ CLOUDFLARE_TUNNEL_TOKEN={{ cloudflare_tunnel_token }}
 {% endif %}
 ### END Cloudflare
 
-### BEGIN Authentik
 {% if hmsdocker_authentik_enabled_globally %}
-AUTHENTIK_TAG=2023.10
+### BEGIN Authentik
+AUTHENTIK_TAG=latest
 {# Pull in the slurped data and decode it. #}
 {# Separate files are used for these as they're supposed to remain persistent and should not be changed, and docker-compose cannot use an env_file setting and also reference it within compose in a ${} variable #}
 AUTHENTIK_SECRET_KEY={{ authentik_key -}}
@@ -70,8 +70,8 @@ PG_DB={{ authentik_pgdb }}
 GEOIP_ACC_ID: "{{ authentik_geoip_account_id }}"
 GEOIP_LIC_KEY: "{{ authentik_geoip_license_key }}"
 {% endif %}
-{% endif %}
 ### END Authentik
+{% endif %}
 
 {% if hmsdocker_container_enabled_tailscale %}
 ### BEGIN Tailscale
@@ -81,49 +81,49 @@ TAILSCALE_AUTH_KEY={{ tailscale_auth_key }}
 
 {% if hmsdocker_container_enabled_homepage %}
 ### BEGIN Homepage
-{% if hmsdocker_homepage_enabled_sonarr %}
-SONARR_KEY={{ sonarr_key | default('') }}
-SONARR_4K_KEY={{ sonarr_4k_key | default('') }}
+{% if hmsdocker_homepage_enabled_sonarr and hmsdocker_container_enabled_sonarr %}
+SONARR_KEY={{ sonarr_key | default('# Will be obtained on 2nd run of playbook' if ansible_check_mode else '') }}
+SONARR_4K_KEY={{ sonarr_4k_key | default('# Will be obtained on 2nd run of playbook' if ansible_check_mode else '') }}
 {% endif %}
-{% if hmsdocker_homepage_enabled_radarr %}
-RADARR_KEY={{ radarr_key | default('') }}
-RADARR_4K_KEY={{ radarr_4k_key | default('') }}
+{% if hmsdocker_homepage_enabled_radarr and hmsdocker_container_enabled_radarr %}
+RADARR_KEY={{ radarr_key | default('# Will be obtained on 2nd run of playbook' if ansible_check_mode else '') }}
+RADARR_4K_KEY={{ radarr_4k_key | default('# Will be obtained on 2nd run of playbook' if ansible_check_mode else '') }}
 {% endif %}
-{% if hmsdocker_homepage_enabled_prowlarr %}
-PROWLARR_KEY={{ prowlarr_key | default('') }}
+{% if hmsdocker_homepage_enabled_prowlarr and hmsdocker_container_enabled_prowlarr %}
+PROWLARR_KEY={{ prowlarr_key | default('# Will be obtained on 2nd run of playbook' if ansible_check_mode else '') }}
 {% endif %}
-{% if hmsdocker_homepage_enabled_sabnzbd %}
-SABNZBD_KEY={{ homepage_sabnzbd_key | default('') }}
+{% if hmsdocker_homepage_enabled_sabnzbd and hmsdocker_container_enabled_sabnzbd %}
+SABNZBD_KEY={{ sabnzbd_key | default('# Will be obtained on 2nd run of playbook' if ansible_check_mode else '') }}
 {% endif %}
-{% if hmsdocker_homepage_enabled_nzbget %}
+{% if hmsdocker_homepage_enabled_nzbget and hmsdocker_container_enabled_nzbget %}
 NZBGET_KEY={{ homepage_nzbget_key | default('') }}
 {% endif %}
-{% if hmsdocker_homepage_enabled_tautulli %}
-TAUTULLI_KEY={{ homepage_tautulli_key | default('') }}
+{% if hmsdocker_homepage_enabled_tautulli and hmsdocker_container_enabled_tautulli %}
+TAUTULLI_KEY={{ tautulli_key | default('# Will be obtained on 2nd run of playbook' if ansible_check_mode else '') }}
 {% endif %}
-{% if hmsdocker_homepage_enabled_plex %}
-PLEX_KEY={{ homepage_plex_key | default('') }}
+{% if hmsdocker_homepage_enabled_plex and hmsdocker_container_enabled_plex %}
+PLEX_KEY={{ plex_key | default('# Will be obtained on 2nd run of playbook' if ansible_check_mode else '') }}
 {% endif %}
-{% if hmsdocker_homepage_enabled_overseerr %}
-OVERSEERR_KEY={{ homepage_overseerr_key | default('') }}
+{% if hmsdocker_homepage_enabled_overseerr and hmsdocker_container_enabled_overseerr %}
+OVERSEERR_KEY={{ overseerr_key.main.apiKey | default('# Will be obtained on 2nd run of playbook' if ansible_check_mode else '') }}
 {% endif %}
-{% if hmsdocker_homepage_enabled_bazarr %}
-BAZARR_KEY={{ homepage_bazarr_key | default('') }}
+{% if hmsdocker_homepage_enabled_bazarr and hmsdocker_container_enabled_bazarr %}
+BAZARR_KEY={{ bazarr_key.auth.apikey | default('# Will be obtained on 2nd run of playbook' if ansible_check_mode else '') }}
 {% endif %}
-{% if hmsdocker_homepage_enabled_authentik %}
+{% if hmsdocker_homepage_enabled_authentik and hmsdocker_container_enabled_authentik %}
 AUTHENTIK_KEY={{ homepage_authentik_key | default('') }}
 {% endif %}
-{% if hmsdocker_homepage_enabled_portainer %}
+{% if hmsdocker_homepage_enabled_portainer and hmsdocker_container_enabled_portainer %}
 PORTAINER_KEY={{ homepage_portainer_key | default('') }}
 {% endif %}
-{% if hmsdocker_homepage_enabled_readarr %}
-READARR_KEY={{ homepage_readarr_key | default('') }}
+{% if hmsdocker_homepage_enabled_readarr and hmsdocker_container_enabled_readarr %}
+READARR_KEY={{ readarr_key | default('# Will be obtained on 2nd run of playbook' if ansible_check_mode else '') }}
 {% endif %}
-WATCHTOWER_KEY={{ watchtower_key  | default('') }}
-{% if hmsdocker_homepage_enabled_jellyfin %}
+WATCHTOWER_KEY={{ watchtower_key | default('') }}
+{% if hmsdocker_homepage_enabled_jellyfin and hmsdocker_container_enabled_jellyfin %}
 JELLYFIN_KEY={{ homepage_jellyfin_key | default('') }}
 {% endif %}
-{% if hmsdocker_homepage_enabled_emby %}
+{% if hmsdocker_homepage_enabled_emby and hmsdocker_container_enabled_emby %}
 EMBY_KEY={{ homepage_emby_key | default('') }}
 {% endif %}
 ### END Homepage

--- a/roles/hmsdocker/templates/env.j2
+++ b/roles/hmsdocker/templates/env.j2
@@ -82,15 +82,15 @@ TAILSCALE_AUTH_KEY={{ tailscale_auth_key }}
 {% if hmsdocker_container_enabled_homepage %}
 ### BEGIN Homepage
 {% if hmsdocker_homepage_enabled_sonarr %}
-SONARR_KEY={{ homepage_sonarr_key | default('') }}
-SONARR_4K_KEY={{ homepage_sonarr_4k_key | default('') }}
+SONARR_KEY={{ sonarr_key | default('') }}
+SONARR_4K_KEY={{ sonarr_4k_key | default('') }}
 {% endif %}
 {% if hmsdocker_homepage_enabled_radarr %}
-RADARR_KEY={{ homepage_radarr_key | default('') }}
-RADARR_4K_KEY={{ homepage_radarr_4k_key | default('') }}
+RADARR_KEY={{ radarr_key | default('') }}
+RADARR_4K_KEY={{ radarr_4k_key | default('') }}
 {% endif %}
 {% if hmsdocker_homepage_enabled_prowlarr %}
-PROWLARR_KEY={{ homepage_prowlarr_key | default('') }}
+PROWLARR_KEY={{ prowlarr_key | default('') }}
 {% endif %}
 {% if hmsdocker_homepage_enabled_sabnzbd %}
 SABNZBD_KEY={{ homepage_sabnzbd_key | default('') }}


### PR DESCRIPTION
Adds parsing to retrieve API keys from the apps config files.

Will automatically add them to the `.env` file on the 2nd playbook run against a new host. This is due to order of operations, the `.env` file must exist for the Compose project to start but the config files for the apps (with the API keys) are not generated until the container starts in the compose project. The 2nd run will retrieve the keys and put them into the `.env` file.

This prevents people from having to get the API keys from the apps GUI and put them into the variable files and running it again anyways