### PR TITLE
Update prowlarr tag prefix character

### DIFF
--- a/roles/hmsdocker/tasks/app_inits/prowlarr.yml
+++ b/roles/hmsdocker/tasks/app_inits/prowlarr.yml
@@ -31,7 +31,7 @@
     - name: Prowlarr bootstrap - Set Prowlarr Tag Facts
       ansible.builtin.set_fact:
         prowlarr_tag_list: "{{ prowlarr_tags.json | items2dict(key_name='label', value_name='id') }}"
-        prowlarr_proxy_tag_prefix: hmsd_
+        prowlarr_proxy_tag_prefix: hmsd-
 
     - name: Prowlarr bootstrap - Create Prowlarr Tags if not exist
       when: prowlarr_proxy_tag_prefix + item not in prowlarr_tag_list.keys() and item in enabled_containers


### PR DESCRIPTION
Changes the Prowlarr tag prefix characters. Changes the `_` to `-` due to change in Prowlarr tag validation

References:
https://github.com/Prowlarr/Prowlarr/releases/tag/v2.0.5.5160
https://github.com/Prowlarr/Prowlarr/commit/3aed39dd52584e35e5aa51b9efc8724d04d4d780