### PR TITLE
Fix Makefile race condition with REMOTE_CONFIG_URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ BASEDIR=$(shell pwd)
 
 CUSTOM_CONF_DIR = inventory/group_vars/all
 
+REMOTE_CONFIG_URL = https://hmsdocker.dev/configs
+
 ARCH = $(shell uname -m)
 BIN_DIR = ./bin
 YQ_LOCAL = $(BIN_DIR)/yq
@@ -98,7 +100,7 @@ update: $(YQ_LOCAL)
 	@grep -q '^hmsdocker_vpn_type:' $(CUSTOM_CONF_DIR)/vpn.yml || echo "hmsdocker_vpn_type: ''" >> $(CUSTOM_CONF_DIR)/vpn.yml
 	@sed -i 's\hms_docker_plex_ssl_subdomain:\hms_docker_plex_ssl_public_hostname:\g' $(CUSTOM_CONF_DIR)/plex.yml
 
-	@REMOTE_CONFIG_URL="https://hmsdocker.dev/configs"; \
+	@REMOTE_CONFIG_URL=$$(grep -oP '^REMOTE_CONFIG_URL\s*=\s*\K.*' Makefile | tr -d ' '); \
 	echo "Fetching container map updates from $$REMOTE_CONFIG_URL/container_map.yml..."; \
 	tmpfile=$$(mktemp); \
 	curl -s "$$REMOTE_CONFIG_URL/container_map.yml" > "$$tmpfile"; \


### PR DESCRIPTION
## Summary

- Fixes a race condition in the `update` target where `REMOTE_CONFIG_URL` was expanded by Make at parse time, before `git pull` could update the Makefile with a new URL
- The URL is now re-read from the on-disk Makefile after `git pull` completes, so it always picks up the latest value
- The top-level Make variable is preserved as the single source of truth

## Test plan

- [ ] Run `make update` and verify the correct `REMOTE_CONFIG_URL` is used in the fetch step
- [ ] Simulate a URL change by modifying `REMOTE_CONFIG_URL` in the Makefile, then verify `make update` picks up the new value after `git pull`

https://claude.ai/code/session_01Ch9AJz1jWQjiD2WDuPuoqv