### PR TITLE
Add variable migration system for inventory compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,15 +90,19 @@ manager:
 update: $(YQ_LOCAL)
 	@echo "Version Before: $$($(YQ_LOCAL) '.[0].vars.hmsd_current_version' hms-docker.yml)"
 	@echo "Updating from Git repo..." && git pull origin master -q
-	@echo "Updating variables..."
-	@sed -i 's\traefik_ext_hosts_configs_path:\hmsdocker_traefik_static_config_location:\g' $(CUSTOM_CONF_DIR)/traefik.yml
-	@sed -i 's\hms_docker_library_path\hmsdocker_library_path\g' $(CUSTOM_CONF_DIR)/hmsd_advanced.yml
-	@sed -i 's\transmission_vpn_provider:\hmsdocker_vpn_provider:\g' $(CUSTOM_CONF_DIR)/transmission.yml
-	@sed -i 's\transmission_vpn_user:\hmsdocker_vpn_user:\g' $(CUSTOM_CONF_DIR)/transmission.yml
-	@sed -i 's\transmission_vpn_pass:\hmsdocker_vpn_pass:\g' $(CUSTOM_CONF_DIR)/transmission.yml
-	@sed -i 's\transmission_ovpn_config_local_path:\transmission_ovpn_config_local_dir:\g' $(CUSTOM_CONF_DIR)/transmission.yml
-	@grep -q '^hmsdocker_vpn_type:' $(CUSTOM_CONF_DIR)/vpn.yml || echo "hmsdocker_vpn_type: ''" >> $(CUSTOM_CONF_DIR)/vpn.yml
-	@sed -i 's\hms_docker_plex_ssl_subdomain:\hms_docker_plex_ssl_public_hostname:\g' $(CUSTOM_CONF_DIR)/plex.yml
+	@echo "Applying variable renames from migrations/variable_renames.yml..."
+	@$(YQ_LOCAL) -r '.variable_renames[] | .old + ":" + .new' migrations/variable_renames.yml \
+		| while IFS=: read old new; do \
+			for f in $(CUSTOM_CONF_DIR)/*.yml; do \
+				[ -f "$$f" ] || continue; \
+				if [ "$$($(YQ_LOCAL) "has(\"$$old\")" "$$f" 2>/dev/null)" = "true" ]; then \
+					$(YQ_LOCAL) -i "with_entries(.key |= sub(\"^$$old\$$\", \"$$new\"))" "$$f"; \
+					echo "  renamed $$old -> $$new in $$(basename $$f)"; \
+				fi; \
+			done; \
+		done
+	@grep -q '^hmsdocker_vpn_type:' $(CUSTOM_CONF_DIR)/vpn.yml 2>/dev/null \
+		|| echo "hmsdocker_vpn_type: ''" >> $(CUSTOM_CONF_DIR)/vpn.yml
 
 	@REMOTE_CONFIG_URL=$$(grep -oP '^REMOTE_CONFIG_URL\s*=\s*\K.*' Makefile | tr -d ' '); \
 	echo "Fetching container map updates from $$REMOTE_CONFIG_URL/container_map.yml..."; \

--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,8 @@ update: $(YQ_LOCAL)
 		| while IFS=: read old new; do \
 			for f in $(CUSTOM_CONF_DIR)/*.yml; do \
 				[ -f "$$f" ] || continue; \
-				if [ "$$($(YQ_LOCAL) "has(\"$$old\")" "$$f" 2>/dev/null)" = "true" ]; then \
-					$(YQ_LOCAL) -i "with_entries(.key |= sub(\"^$$old\$$\", \"$$new\"))" "$$f"; \
+				if grep -qE "^[[:space:]]*$$old:" "$$f"; then \
+					sed -i -E "s/^([[:space:]]*)$$old:/\1$$new:/" "$$f"; \
 					echo "  renamed $$old -> $$new in $$(basename $$f)"; \
 				fi; \
 			done; \

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ apply: install-reqs
 
 install-reqs:
 	@ansible-galaxy install -r galaxy-requirements.yml -p ./galaxy-roles
+	@ansible-galaxy collection install community.docker community.general
 
 verify-containers:
 	@sudo python3 .github/workflows/scripts/check_containers.py

--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,6 @@ update: $(YQ_LOCAL)
 				fi; \
 			done; \
 		done
-	@grep -q '^hmsdocker_vpn_type:' $(CUSTOM_CONF_DIR)/vpn.yml 2>/dev/null \
-		|| echo "hmsdocker_vpn_type: ''" >> $(CUSTOM_CONF_DIR)/vpn.yml
 
 	@REMOTE_CONFIG_URL=$$(grep -oP '^REMOTE_CONFIG_URL\s*=\s*\K.*' Makefile | tr -d ' '); \
 	echo "Fetching container map updates from $$REMOTE_CONFIG_URL/container_map.yml..."; \

--- a/README.md
+++ b/README.md
@@ -47,3 +47,7 @@ Please see the docs page at: https://hmsdocker.dev
 Pull requests are always welcome!
 
 If you have suggestions for containers to add or any other improvements, please submit a [Discussion Post](https://github.com/ahembree/ansible-hms-docker/discussions)
+
+## AI Disclaimer
+
+AI is starting to make contributions to this codebase. With that said, 95%+ of it was still written by hand. I have used AI to develop the Unifi DNS integration, refine the update process for new playbook versions, and update/align documentation. The first offical 1.0 release was in [January of 2022](https://github.com/ahembree/ansible-hms-docker/releases/tag/1.0.0), long before AI was actually useful.

--- a/docs-astro/src/content/docs/docs/release-notes/v1.18.md
+++ b/docs-astro/src/content/docs/docs/release-notes/v1.18.md
@@ -5,6 +5,14 @@ sidebar:
   order: -18
 ---
 
+## v1.18.1
+
+No new (useful) features, adds a compatability shim layer for variable renames/migrations to make upcoming releases much easier.
+
+Installs `community.docker` and `community.general` ansible collections by default
+
+Add AI disclaimer to bottom of GitHub readme.
+
 ## v1.18.0
 
 ### New Containers

--- a/hms-docker.yml
+++ b/hms-docker.yml
@@ -5,7 +5,7 @@
   gather_facts: true
   vars:
     # Must be 3-part semantic format so Ansible can correctly compare versions (version X.Y.Z)
-    hmsd_current_version: 1.18.0
+    hmsd_current_version: 1.18.1
     hmsd_version_file: "{{ hms_docker_data_path }}/.hmsd-version"
     is_github_runner: false
     regex: '[^A-Za-z0-9._-]'

--- a/migrations/variable_renames.yml
+++ b/migrations/variable_renames.yml
@@ -7,7 +7,9 @@
 #       have not yet rewritten their inventory still get a working apply.
 #   - Makefile `update` target
 #       Rewrites the on-disk inventory files under inventory/group_vars/all
-#       using yq, so the rename is persisted at upgrade time.
+#       so the rename is persisted at upgrade time. Renames are anchored to
+#       the start of a line so they only match YAML keys, not occurrences
+#       of the same string inside values or comments.
 #
 # To register a new rename, append an entry to `variable_renames` below.
 # Both consumers pick it up automatically — no other file edits required.

--- a/migrations/variable_renames.yml
+++ b/migrations/variable_renames.yml
@@ -1,0 +1,25 @@
+---
+# Single source of truth for deprecated -> new inventory variable renames.
+#
+# Consumed by:
+#   - roles/hmsdocker/tasks/compat_shim.yml
+#       Aliases old -> new in-memory during a playbook run so users who
+#       have not yet rewritten their inventory still get a working apply.
+#   - Makefile `update` target
+#       Rewrites the on-disk inventory files under inventory/group_vars/all
+#       using yq, so the rename is persisted at upgrade time.
+#
+# To register a new rename, append an entry to `variable_renames` below.
+# Both consumers pick it up automatically — no other file edits required.
+#
+# Entries should describe top-level YAML keys. Nested-key renames need
+# bespoke handling and are not covered by this file.
+
+variable_renames:
+  - { old: traefik_ext_hosts_configs_path,      new: hmsdocker_traefik_static_config_location }
+  - { old: hms_docker_library_path,             new: hmsdocker_library_path }
+  - { old: transmission_vpn_provider,           new: hmsdocker_vpn_provider }
+  - { old: transmission_vpn_user,               new: hmsdocker_vpn_user }
+  - { old: transmission_vpn_pass,               new: hmsdocker_vpn_pass }
+  - { old: transmission_ovpn_config_local_path, new: transmission_ovpn_config_local_dir }
+  - { old: hms_docker_plex_ssl_subdomain,       new: hms_docker_plex_ssl_public_hostname }

--- a/roles/hmsdocker/tasks/compat_shim.yml
+++ b/roles/hmsdocker/tasks/compat_shim.yml
@@ -39,6 +39,12 @@
   loop: "{{ hmsdocker_active_migrations }}"
   loop_control:
     label: "{{ item.old }} -> {{ item.new }}"
+  # Skip null / empty old values: Jinja stringifies None as the literal
+  # "None", which would silently bypass downstream length-based asserts.
+  when: (lookup('vars', item.old) | default('', true) | string) | length > 0
+  # Old values may include credentials (e.g. transmission_vpn_pass).
+  # Match the rest of preflight's no_log pattern.
+  no_log: "{{ not (debug_mode | default(false) | bool) }}"
 
 - name: (compat) Record deprecation warnings for renamed variables
   ansible.builtin.set_fact:

--- a/roles/hmsdocker/tasks/compat_shim.yml
+++ b/roles/hmsdocker/tasks/compat_shim.yml
@@ -7,28 +7,18 @@
 # a notice to hmsdocker_preflight_warnings so the user knows to update their
 # inventory at their leisure.
 #
-# To register a new rename, append an entry to hmsdocker_variable_migrations:
-#   - { old: "old_var_name", new: "new_var_name" }
-# Re-runs are safe: entries whose `old` is unset in the resolved vars are
-# silently skipped. If the user sets `old` only, `new` is aliased to it.
-# If they set both, `new` wins because set_fact runs after they're both
-# already resolved and we only assign when `old` is defined — meaning the
-# user explicitly carried over the old name; we still prefer that explicit
-# intent and warn them to remove it.
-#
-# This shim mirrors the sed-based renames in the Makefile `update` target.
-# Keep the two lists in sync when adding new migrations.
+# The rename map lives in migrations/variable_renames.yml at the repo root
+# and is shared with the Makefile `update` target — register new renames
+# there, not here. Re-runs are safe: entries whose `old` is unset in the
+# resolved vars are silently skipped.
 
-- name: (compat) Define deprecated -> new variable migration map
+- name: (compat) Load variable migration map from single source
   ansible.builtin.set_fact:
-    hmsdocker_variable_migrations:
-      - { old: "traefik_ext_hosts_configs_path",      new: "hmsdocker_traefik_static_config_location" }
-      - { old: "hms_docker_library_path",             new: "hmsdocker_library_path" }
-      - { old: "transmission_vpn_provider",           new: "hmsdocker_vpn_provider" }
-      - { old: "transmission_vpn_user",               new: "hmsdocker_vpn_user" }
-      - { old: "transmission_vpn_pass",               new: "hmsdocker_vpn_pass" }
-      - { old: "transmission_ovpn_config_local_path", new: "transmission_ovpn_config_local_dir" }
-      - { old: "hms_docker_plex_ssl_subdomain",       new: "hms_docker_plex_ssl_public_hostname" }
+    hmsdocker_variable_migrations: >-
+      {{
+        (lookup('file', playbook_dir ~ '/migrations/variable_renames.yml')
+         | from_yaml).variable_renames
+      }}
 
 # `vars` is the magic dict of all currently-resolved variables. Membership
 # (`in vars`) tells us whether the deprecated name was set by inventory or a

--- a/roles/hmsdocker/tasks/compat_shim.yml
+++ b/roles/hmsdocker/tasks/compat_shim.yml
@@ -1,0 +1,63 @@
+---
+# Compatibility shim for deprecated/renamed inventory variables.
+#
+# When a user upgrades, their inventory may still define old variable names.
+# Rather than failing (or requiring them to run `make update` first), this
+# task aliases each deprecated variable to its new name in-memory and appends
+# a notice to hmsdocker_preflight_warnings so the user knows to update their
+# inventory at their leisure.
+#
+# To register a new rename, append an entry to hmsdocker_variable_migrations:
+#   - { old: "old_var_name", new: "new_var_name" }
+# Re-runs are safe: entries whose `old` is unset in the resolved vars are
+# silently skipped. If the user sets `old` only, `new` is aliased to it.
+# If they set both, `new` wins because set_fact runs after they're both
+# already resolved and we only assign when `old` is defined — meaning the
+# user explicitly carried over the old name; we still prefer that explicit
+# intent and warn them to remove it.
+#
+# This shim mirrors the sed-based renames in the Makefile `update` target.
+# Keep the two lists in sync when adding new migrations.
+
+- name: (compat) Define deprecated -> new variable migration map
+  ansible.builtin.set_fact:
+    hmsdocker_variable_migrations:
+      - { old: "traefik_ext_hosts_configs_path",      new: "hmsdocker_traefik_static_config_location" }
+      - { old: "hms_docker_library_path",             new: "hmsdocker_library_path" }
+      - { old: "transmission_vpn_provider",           new: "hmsdocker_vpn_provider" }
+      - { old: "transmission_vpn_user",               new: "hmsdocker_vpn_user" }
+      - { old: "transmission_vpn_pass",               new: "hmsdocker_vpn_pass" }
+      - { old: "transmission_ovpn_config_local_path", new: "transmission_ovpn_config_local_dir" }
+      - { old: "hms_docker_plex_ssl_subdomain",       new: "hms_docker_plex_ssl_public_hostname" }
+
+# `vars` is the magic dict of all currently-resolved variables. Membership
+# (`in vars`) tells us whether the deprecated name was set by inventory or a
+# previously-running task. We snapshot it once so all later steps agree on
+# which migrations are active.
+- name: (compat) Determine which deprecated variables are in use
+  ansible.builtin.set_fact:
+    hmsdocker_active_migrations: >-
+      {{
+        hmsdocker_variable_migrations
+        | selectattr('old', 'in', vars)
+        | list
+      }}
+
+- name: (compat) Alias deprecated variables to their new names
+  ansible.builtin.set_fact:
+    "{{ item.new }}": "{{ lookup('vars', item.old) }}"
+  loop: "{{ hmsdocker_active_migrations }}"
+  loop_control:
+    label: "{{ item.old }} -> {{ item.new }}"
+
+- name: (compat) Record deprecation warnings for renamed variables
+  ansible.builtin.set_fact:
+    hmsdocker_preflight_warnings: >-
+      {{
+        hmsdocker_preflight_warnings
+        + ["DEPRECATED: '" ~ item.old ~ "' has been renamed to '" ~ item.new
+           ~ "'. Update your inventory (or run `make update`) - the old name will be removed in a future release."]
+      }}
+  loop: "{{ hmsdocker_active_migrations }}"
+  loop_control:
+    label: "{{ item.old }} -> {{ item.new }}"

--- a/roles/hmsdocker/tasks/compat_shim.yml
+++ b/roles/hmsdocker/tasks/compat_shim.yml
@@ -20,16 +20,16 @@
          | from_yaml).variable_renames
       }}
 
-# `vars` is the magic dict of all currently-resolved variables. Membership
-# (`in vars`) tells us whether the deprecated name was set by inventory or a
-# previously-running task. We snapshot it once so all later steps agree on
-# which migrations are active.
+# `q('varnames', '.*')` returns the names of all currently-resolved
+# variables. We snapshot it once so all later steps agree on which
+# migrations are active, and intersect it with the migration map to find
+# deprecated names the user actually set.
 - name: (compat) Determine which deprecated variables are in use
   ansible.builtin.set_fact:
     hmsdocker_active_migrations: >-
       {{
         hmsdocker_variable_migrations
-        | selectattr('old', 'in', vars)
+        | selectattr('old', 'in', q('varnames', '.*'))
         | list
       }}
 

--- a/roles/hmsdocker/tasks/preflight.yml
+++ b/roles/hmsdocker/tasks/preflight.yml
@@ -16,6 +16,12 @@
   ansible.builtin.set_fact:
     hmsdocker_preflight_warnings: []
 
+# Alias deprecated inventory variable names to their new names before any
+# assert below checks the new names. See tasks/compat_shim.yml for the
+# migration map and instructions for adding new entries.
+- name: (preflight) Apply deprecated variable compatibility shim
+  ansible.builtin.import_tasks: "compat_shim.yml"
+
 # ---------------------------------------------------------------------------
 # Always-required: foundational vars used unguarded by the role
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
This PR introduces a centralized variable migration system to handle deprecated/renamed inventory variables gracefully during upgrades. Users can now upgrade without immediately updating their inventory files, while receiving clear deprecation warnings.

## Key Changes
- **New compatibility shim task** (`roles/hmsdocker/tasks/compat_shim.yml`): Automatically aliases deprecated variable names to their new names in-memory during playbook execution, allowing old inventories to continue working
- **Centralized migration map** (`migrations/variable_renames.yml`): Single source of truth for all variable renames, shared between the Ansible compatibility shim and the Makefile `update` target
- **Updated Makefile `update` target**: Refactored to dynamically read from the migration map instead of hardcoded sed commands, making it easier to add new renames
- **Integrated preflight checks**: The compatibility shim runs early in preflight validation and records deprecation warnings so users know to update their inventory
- **Added collection dependencies**: Explicitly install `community.docker` and `community.general` collections during `make install-reqs`
- **Documentation**: Added AI disclaimer to README

## Implementation Details
- The migration system is non-destructive: old variable names are aliased to new ones in-memory without modifying the user's inventory files
- Deprecation warnings are appended to `hmsdocker_preflight_warnings` so users see them during playbook execution
- The system safely skips migrations where the old variable is unset, preventing false positives
- Sensitive values (like VPN credentials) are protected with `no_log` during the aliasing process
- The Makefile `update` target now uses regex-based sed to match YAML keys at line start, ensuring it only renames keys, not values or comments

https://claude.ai/code/session_01CQbnNQStFD7Jm9vd5wk86Y