### PR TITLE
fix(vpn): resolve PIA/WireGuard restart loop and map provider to VPN_PROV

### DIFF
--- a/docs-astro/src/content/docs/docs/getting-started/container-overrides.mdx
+++ b/docs-astro/src/content/docs/docs/getting-started/container-overrides.mdx
@@ -40,23 +40,28 @@ sudo docker compose config
 
 ## Private Internet Access (PIA)
 
-The Deluge and qBittorrent containers have native support for the VPN provider Private Internet Access (PIA).
+The Deluge and qBittorrent containers natively support PIA. Set the following in `inventory/group_vars/all/vpn.yml`:
 
-These containers also support port forwarding through PIA, but this means you will only be able to connect to endpoints that support port forwarding.
+```yaml
+hmsdocker_vpn_type: wireguard
+hmsdocker_vpn_provider: pia
+hmsdocker_vpn_user: <your PIA username>
+hmsdocker_vpn_pass: <your PIA password>
+```
 
-For more information on this port forwarding feature, see Question 15 (Q15) here: [Binhex Documentation](https://github.com/binhex/documentation/blob/master/docker/faq/vpn.md)
+`hmsdocker_vpn_provider` is passed through to the container's `VPN_PROV`; with `pia` the container generates its own WireGuard config, so you don't supply a `wg0.conf`.
 
-In order to enable this port forwarding, you will need to add the following to the "override" file specified above (`/opt/hms-docker/docker-compose.override.yml`):
+### Port forwarding
+
+PIA port forwarding only connects to endpoints that support it (see Q15 of the [Binhex docs](https://github.com/binhex/documentation/blob/master/docker/faq/vpn.md)). It isn't a playbook variable, so enable it by adding `STRICT_PORT_FORWARD=yes` to the override file (`/opt/hms-docker/docker-compose.override.yml`):
 
 ```yaml
 #/opt/hms-docker/docker-compose.override.yml
 services:
   qbittorrent:
     environment:
-      - VPN_PROV=pia
-      - STRICT_PORT_FORWARDING=yes
+      - STRICT_PORT_FORWARD=yes
   deluge:
     environment:
-      - VPN_PROV=pia
-      - STRICT_PORT_FORWARDING=yes
+      - STRICT_PORT_FORWARD=yes
 ```

--- a/docs-astro/src/content/docs/docs/getting-started/vpn-and-dl-clients.mdx
+++ b/docs-astro/src/content/docs/docs/getting-started/vpn-and-dl-clients.mdx
@@ -138,7 +138,7 @@ This folder will not exist until the playbook is ran or the container runs for t
 
 ### Private Internet Access (PIA)
 
-If you are using PIA and want to use port forwarding through the VPN, see the [Container Overrides](/docs/getting-started/container-overrides) docs
+Set `hmsdocker_vpn_provider: pia`; with WireGuard the container generates its own config, so you don't place a `wg0.conf`. See [Container Overrides](/docs/getting-started/container-overrides) for details and port forwarding.
 
 
 
@@ -180,4 +180,4 @@ This folder will not exist until the playbook is ran or the container runs for t
 
 ### Private Internet Access (PIA)
 
-If you are using PIA and want to use port forwarding through the VPN, see the [Container Overrides](/docs/getting-started/container-overrides) docs
+Set `hmsdocker_vpn_provider: pia`; with WireGuard the container generates its own config, so you don't place a `wg0.conf`. See [Container Overrides](/docs/getting-started/container-overrides) for details and port forwarding.

--- a/docs-astro/src/content/docs/docs/release-notes/v1.18.md
+++ b/docs-astro/src/content/docs/docs/release-notes/v1.18.md
@@ -5,6 +5,14 @@ sidebar:
   order: -18
 ---
 
+## v1.18.7
+
+### VPN / download clients
+
+Fixed a qBittorrent/Deluge restart loop when using PIA over WireGuard, caused by the playbook leaving an empty `wg0.conf` stub that the container treated as a manual config.
+
+`hmsdocker_vpn_provider` is now mapped to the container's `VPN_PROV` for qBittorrent/Deluge (`pia`, `airvpn`, `protonvpn`, or `custom`; any other value falls back to `custom`). PIA over WireGuard now works from `vpn.yml` alone by setting `hmsdocker_vpn_provider: pia`, without a `docker-compose.override.yml`.
+
 ## v1.18.6
 
 Remove `security_opt:no-new-privileges` from Tdarr since it prevents it from working correctly

--- a/hms-docker.yml
+++ b/hms-docker.yml
@@ -5,7 +5,7 @@
   gather_facts: true
   vars:
     # Must be 3-part semantic format so Ansible can correctly compare versions (version X.Y.Z)
-    hmsd_current_version: 1.18.6
+    hmsd_current_version: 1.18.7
     hmsd_version_file: "{{ hms_docker_data_path }}/.hmsd-version"
     is_github_runner: false
     regex: '[^A-Za-z0-9._-]'

--- a/roles/hmsdocker/defaults/main/vpn.yml
+++ b/roles/hmsdocker/defaults/main/vpn.yml
@@ -5,11 +5,10 @@
 #     `custom` requires variables to be configured in `inventory/group_vars/all/transmission.yml`
 hmsdocker_vpn_type: openvpn
 
-# If using `transmission`, find your provider here: https://haugene.github.io/docker-transmission-openvpn/supported-providers/
-# If using `qbittorrent` or `deluge`, you must copy your VPN config file
-#   to the container config directory (default: /opt/hms-docker/apps/<container>/config/<vpn_type>)
-# NOTE: these directories will be automatically generated after first playbook run
-# Restart the container using `docker restart <container>` after modifying the files
+# transmission: https://haugene.github.io/docker-transmission-openvpn/supported-providers/
+# qbittorrent/deluge: passed through as VPN_PROV if pia/airvpn/protonvpn/custom, else custom.
+#   `pia` self-configures; the others need your config file in the container config
+#   directory (default: /opt/hms-docker/apps/<container>/config/<vpn_type>, auto-created).
 hmsdocker_vpn_provider:
 
 # Your VPN credentials if authentication is not embedded in the config file

--- a/roles/hmsdocker/tasks/preflight.yml
+++ b/roles/hmsdocker/tasks/preflight.yml
@@ -200,14 +200,10 @@
 # ---------------------------------------------------------------------------
 # VPN-using download clients
 #
-# Only transmission consumes hmsdocker_vpn_provider (templates/env.j2 exports
-# it as VPN_PROVIDER, which transmission.yml.j2 maps to OPENVPN_PROVIDER).
-# qbittorrent and deluge hardcode VPN_PROV=custom in their compose templates
-# and read configs from config/<hmsdocker_vpn_type>/ - the provider name is
-# irrelevant to them.
-#
-# Transmission's `custom` vpn_type is exempt because the config comes from
-# a local file rather than the provider list.
+# Only transmission requires a provider from a fixed list, so it is the only one
+# asserted here. qbittorrent/deluge map the provider to VPN_PROV in their
+# templates and fall back to 'custom'. Transmission's 'custom' vpn_type is exempt
+# because the config comes from a local file rather than the provider list.
 # ---------------------------------------------------------------------------
 
 - name: (preflight) Validate VPN provider for Transmission

--- a/roles/hmsdocker/tasks/vpn_setup.yml
+++ b/roles/hmsdocker/tasks/vpn_setup.yml
@@ -11,6 +11,7 @@
     - deluge
   when: item in enabled_containers and item != 'transmission' or (item == 'transmission' and hmsdocker_vpn_provider == 'custom' and hmsdocker_vpn_type == 'openvpn')
 
+# Skip the stub for PIA, which generates its own wg0.conf (an empty one aborts it).
 - name: (VPN Setup) Ensure WireGuard config exists with restricted permissions
   ansible.builtin.file:
     path: '{{ hms_docker_apps_path }}/{{ item }}/config/{{ hmsdocker_vpn_type }}/wg0.conf'
@@ -21,7 +22,33 @@
   when:
     - item in enabled_containers
     - hmsdocker_vpn_type == 'wireguard'
+    - (hmsdocker_vpn_provider | default('', true)) | lower != 'pia'
   loop:
     - qbittorrent
     - deluge
   changed_when: false
+
+# Remove a leftover empty stub so PIA can generate its own wg0.conf.
+- name: (VPN Setup) Stat wg0.conf for PIA
+  ansible.builtin.stat:
+    path: '{{ hms_docker_apps_path }}/{{ item }}/config/{{ hmsdocker_vpn_type }}/wg0.conf'
+  when:
+    - item in enabled_containers
+    - hmsdocker_vpn_type == 'wireguard'
+    - (hmsdocker_vpn_provider | default('', true)) | lower == 'pia'
+  loop:
+    - qbittorrent
+    - deluge
+  register: hmsdocker_wg_conf_stat
+
+- name: (VPN Setup) Remove empty wg0.conf so PIA can generate its own
+  ansible.builtin.file:
+    path: '{{ hms_docker_apps_path }}/{{ item.item }}/config/{{ hmsdocker_vpn_type }}/wg0.conf'
+    state: absent
+  loop: '{{ hmsdocker_wg_conf_stat.results | default([]) }}'
+  loop_control:
+    label: '{{ item.item | default("") }}'
+  when:
+    - item.stat is defined
+    - item.stat.exists
+    - item.stat.size == 0

--- a/roles/hmsdocker/templates/containers/deluge.yml.j2
+++ b/roles/hmsdocker/templates/containers/deluge.yml.j2
@@ -28,7 +28,7 @@ services:
       - VPN_ENABLED=yes
       - VPN_USER=${VPN_USER}
       - VPN_PASS=${VPN_PASS}
-      - VPN_PROV=custom
+      - VPN_PROV={{ (hmsdocker_vpn_provider | default('', true) | lower) if (hmsdocker_vpn_provider | default('', true) | lower) in ['pia', 'airvpn', 'protonvpn', 'custom'] else 'custom' }}
       - VPN_CLIENT={{ hmsdocker_vpn_type }}
       - ENABLE_PRIVOXY=yes
       - LAN_NETWORK={{ hms_docker_network_subnet }}

--- a/roles/hmsdocker/templates/containers/qbittorrent.yml.j2
+++ b/roles/hmsdocker/templates/containers/qbittorrent.yml.j2
@@ -29,7 +29,7 @@ services:
       - VPN_ENABLED=yes
       - VPN_USER=${VPN_USER}
       - VPN_PASS=${VPN_PASS}
-      - VPN_PROV=custom
+      - VPN_PROV={{ (hmsdocker_vpn_provider | default('', true) | lower) if (hmsdocker_vpn_provider | default('', true) | lower) in ['pia', 'airvpn', 'protonvpn', 'custom'] else 'custom' }}
       - VPN_CLIENT={{ hmsdocker_vpn_type }}
       - ENABLE_PRIVOXY=yes
       - LAN_NETWORK={{ hms_docker_network_subnet }}


### PR DESCRIPTION
qbittorrent/deluge with PIA over WireGuard entered a restart loop: the container
fetches its WireGuard config from the PIA API on startup, but vpn_setup.yml
unconditionally touched an empty /config/wireguard/wg0.conf. Binhex's entrypoint
treats the existing empty file as a manual config and aborts ("does not contain
'Endpoint' line"), which then failed the "Get VPN IPs from containers" task with
a 409 (container restarting).

- vpn_setup.yml: skip creating the wg0.conf stub for PIA, and remove any leftover
  empty stub (size 0) so the container falls back to the PIA API. Non-PIA
  WireGuard (airvpn/protonvpn/custom) still gets the placeholder stub since those
  expect a user-supplied config.
- qbittorrent/deluge templates: derive VPN_PROV from hmsdocker_vpn_provider when
  it is a value the Binhex image accepts (pia/airvpn/protonvpn/custom,
  case-insensitive), else fall back to custom - so PIA now works from vpn.yml
  alone, without a docker-compose.override.yml. Mapping is inlined; no new vars.
- Docs: document PIA via hmsdocker_vpn_provider: pia (override only needed for
  STRICT_PORT_FORWARD, whose env var name is also corrected).
- Bump hmsd_current_version to 1.18.7 and add the v1.18.7 release notes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01F8mJHnsjfxTtatT4A3VuwJ