### PR TITLE
Fix version handling, VPN validation, and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,8 @@ jobs:
       with:
         cmd: yq '.[0].vars.hmsd_current_version' 'hms-docker.yml'
 
-    # The workflow triggers on ANY push touching hms-docker.yml, not just
-    # version bumps. Skip releasing (instead of failing and running the tag
-    # cleanup below against an already-published tag) when this version is
-    # already tagged.
+    # The workflow fires on any push touching hms-docker.yml, not just version
+    # bumps — skip releasing when this version is already tagged.
     - name: Check if version is already tagged
       id: tag_check
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,24 @@ jobs:
       with:
         cmd: yq '.[0].vars.hmsd_current_version' 'hms-docker.yml'
 
+    # The workflow triggers on ANY push touching hms-docker.yml, not just
+    # version bumps. Skip releasing (instead of failing and running the tag
+    # cleanup below against an already-published tag) when this version is
+    # already tagged.
+    - name: Check if version is already tagged
+      id: tag_check
+      run: |
+        VERSION="${{ steps.version.outputs.result }}"
+        if git ls-remote --exit-code origin "refs/tags/v${VERSION}" >/dev/null 2>&1; then
+          echo "This version is already tagged as v${VERSION}; skipping release."
+          echo "exists=true" >> $GITHUB_OUTPUT
+        else
+          echo "exists=false" >> $GITHUB_OUTPUT
+        fi
+
     - name: Bump version and push tag
       id: tag_version
+      if: steps.tag_check.outputs.exists == 'false'
       uses: mathieudutour/github-tag-action@v6.2
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -34,6 +50,7 @@ jobs:
 
     - name: Extract changelog body
       id: changelog_body
+      if: steps.tag_check.outputs.exists == 'false'
       run: |
         VERSION="${{ steps.version.outputs.result }}"
 
@@ -46,6 +63,11 @@ jobs:
           flag
         ' "$FILE")
 
+        if [ -z "$CONTENT" ]; then
+          echo "::error::No release notes found under a '## ${HEADER}' heading in ${FILE}"
+          exit 1
+        fi
+
         {
           echo "content<<EOF"
           echo "$CONTENT"
@@ -53,6 +75,7 @@ jobs:
         } >> $GITHUB_OUTPUT
 
     - name: Create Release
+      if: steps.tag_check.outputs.exists == 'false'
       uses: softprops/action-gh-release@v3
       with:
         tag_name: ${{ steps.tag_version.outputs.new_tag }}
@@ -64,8 +87,9 @@ jobs:
         prerelease: false
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
+    # Only clean up a tag this run actually created — never a pre-existing one.
     - name: Delete tag on failure
-      if: failure() && steps.tag_version.outputs.new_tag != ''
+      if: failure() && steps.tag_version.outcome == 'success' && steps.tag_version.outputs.new_tag != ''
       run: |
         git push --delete origin ${{ steps.tag_version.outputs.new_tag }}

--- a/.github/workflows/scripts/check_containers.py
+++ b/.github/workflows/scripts/check_containers.py
@@ -26,9 +26,8 @@ docker_client = docker.from_env()
 def main():
     container_list = docker_client.containers.list()
 
-    # Compose project to check; must match the playbook's `project_name`.
-    # Override with HMSD_PROJECT_NAME when using a custom project_name,
-    # otherwise no containers match and the run fails with "Did not make any requests".
+    # Must match the playbook's `project_name`; override with HMSD_PROJECT_NAME
+    # when using a custom project name.
     project = os.getenv('HMSD_PROJECT_NAME', 'hms-docker')
 
     requests_made = 0

--- a/.github/workflows/scripts/check_containers.py
+++ b/.github/workflows/scripts/check_containers.py
@@ -26,7 +26,10 @@ docker_client = docker.from_env()
 def main():
     container_list = docker_client.containers.list()
 
-    project = 'hms-docker'
+    # Compose project to check; must match the playbook's `project_name`.
+    # Override with HMSD_PROJECT_NAME when using a custom project_name,
+    # otherwise no containers match and the run fails with "Did not make any requests".
+    project = os.getenv('HMSD_PROJECT_NAME', 'hms-docker')
 
     requests_made = 0
     success_codes = 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,11 +68,11 @@ When renaming a variable, **always** add an entry to `migrations/variable_rename
 
 ### Versioning
 
-`hmsd_current_version` in `hms-docker.yml` (3-part semver — Ansible's version comparison needs it that way) is compared at runtime against the on-disk version file at `{{ hms_docker_data_path }}/.hmsd-version`. Mismatches trigger migration logic in `tasks/versioning.yml`. Bump this when shipping a breaking change that needs a migration.
+`hmsd_current_version` in `hms-docker.yml` (a **quoted** 3-part semver — unquoted values like `1.20` parse as the YAML float `1.2` and break the semver comparison; a runtime assert in `tasks/versioning.yml` enforces the format) is compared at runtime against the on-disk version file at `{{ hms_docker_data_path }}/.hmsd-version`. The on-disk value is normalized before comparison (releases 1.4–1.9 wrote 2-part versions). Mismatches trigger migration logic in `tasks/versioning.yml`; the version file itself is written at the end of `tasks/main.yml` so a failed run re-prompts on retry. Bump this when shipping a breaking change that needs a migration.
 
 **Cutting a release:**
 
-1. Bump `hmsd_current_version` in [hms-docker.yml](hms-docker.yml).
+1. Bump `hmsd_current_version` in [hms-docker.yml](hms-docker.yml), keeping it quoted.
 2. Add a matching `## v<version>` section to the release-notes file for that minor series, e.g. `docs-astro/src/content/docs/docs/release-notes/v1.18.md`. The header must be exactly `## v<version>` (matching the new version) — the release workflow extracts everything between it and the next `## ` heading as the GitHub Release body.
 3. Merge to `master`. [.github/workflows/release.yml](.github/workflows/release.yml) triggers on pushes to `master` that touch `hms-docker.yml`: it reads the version, tags it, and creates the GitHub Release from the extracted notes. Releases are not cut from feature branches.
 

--- a/docs-astro/src/content/docs/docs/release-notes/v1.19.md
+++ b/docs-astro/src/content/docs/docs/release-notes/v1.19.md
@@ -5,6 +5,34 @@ sidebar:
   order: -19
 ---
 
+## v1.19.1
+
+Bug-fix release focused on version checking and upgrade safety.
+
+### Upgrade and versioning fixes
+
+- Upgrading from a release older than v1.9.1 no longer crashes: 2-part versions (e.g. `1.9`) in the on-disk `.hmsd-version` file are normalized before comparison, and empty or corrupt files fall back to `0.0.0`.
+- The version file is now written at the end of the run, so a failed run re-prompts on the next attempt.
+- Answering `no` at the upgrade prompt now aborts immediately instead of after the remaining migration prompts.
+
+### Variable handling
+
+- If you set a renamed variable's new name while the deprecated old name is still present in your inventory, your new value is now used (previously the stale old value silently won). A deprecation warning tells you which name to remove.
+- `hmsdocker_library_path` can now be overridden from `inventory/group_vars/all/hmsd_advanced.yml`.
+- New `cloudflare_ddns_zone` variable: set it in `inventory/group_vars/all/cloudflare.yml` if your domain uses a multi-label public suffix (e.g. `example.co.uk`), which the automatic zone detection derives incorrectly.
+
+### VPN
+
+- The VPN IP check now fails closed: if the public IP lookup or the in-container IP check fails, the download client is stopped instead of being reported as protected — and the check no longer errors mid-run when the lookup fails.
+- Transmission's VPN config directory is no longer created when Transmission is disabled.
+
+### Other changes
+
+- Authentik GeoIP settings are written to the `.env` file in valid `KEY=value` syntax.
+- App API key detection no longer breaks when a config value contains quotes.
+- 4K instance init scripts (arr-scripts) now check the 4K app directory instead of the base one.
+- Release automation: pushes that touch `hms-docker.yml` without a version bump no longer attempt a duplicate release.
+
 ## v1.19.0
 
 ### New container: Byparr

--- a/docs-astro/src/content/docs/docs/release-notes/v1.19.md
+++ b/docs-astro/src/content/docs/docs/release-notes/v1.19.md
@@ -28,6 +28,7 @@ Bug-fix release focused on version checking and upgrade safety.
 
 ### Other changes
 
+- The Nvidia GPU role now adds the `nvidia-container-toolkit` apt repo via `deb822_repository` instead of the deprecated `apt_key`/`apt_repository` modules (removed in ansible-core 2.25), and cleans up the legacy `.list` and `.gpg` files on existing installs.
 - Authentik GeoIP settings are written to the `.env` file in valid `KEY=value` syntax.
 - App API key detection no longer breaks when a config value contains quotes.
 - 4K instance init scripts (arr-scripts) now check the 4K app directory instead of the base one.

--- a/hms-docker.yml
+++ b/hms-docker.yml
@@ -6,7 +6,7 @@
   vars:
     # Must be a QUOTED 3-part semver (X.Y.Z) — unquoted values like 1.20 parse
     # as the YAML float 1.2 and break the version comparison.
-    hmsd_current_version: "1.19.0"
+    hmsd_current_version: "1.19.1"
     hmsd_version_file: "{{ hms_docker_data_path }}/.hmsd-version"
     is_github_runner: false
     regex: '[^A-Za-z0-9._-]'

--- a/hms-docker.yml
+++ b/hms-docker.yml
@@ -4,9 +4,8 @@
   become: true
   gather_facts: true
   vars:
-    # Must be a QUOTED 3-part semantic version (X.Y.Z) so Ansible can correctly
-    # compare versions. Unquoted values like 1.20 are parsed by YAML as the
-    # float 1.2, which breaks the semver comparison for every user.
+    # Must be a QUOTED 3-part semver (X.Y.Z) — unquoted values like 1.20 parse
+    # as the YAML float 1.2 and break the version comparison.
     hmsd_current_version: "1.19.0"
     hmsd_version_file: "{{ hms_docker_data_path }}/.hmsd-version"
     is_github_runner: false

--- a/hms-docker.yml
+++ b/hms-docker.yml
@@ -4,8 +4,10 @@
   become: true
   gather_facts: true
   vars:
-    # Must be 3-part semantic format so Ansible can correctly compare versions (version X.Y.Z)
-    hmsd_current_version: 1.19.0
+    # Must be a QUOTED 3-part semantic version (X.Y.Z) so Ansible can correctly
+    # compare versions. Unquoted values like 1.20 are parsed by YAML as the
+    # float 1.2, which breaks the semver comparison for every user.
+    hmsd_current_version: "1.19.0"
     hmsd_version_file: "{{ hms_docker_data_path }}/.hmsd-version"
     is_github_runner: false
     regex: '[^A-Za-z0-9._-]'

--- a/roles/gpu/tasks/debian.yml
+++ b/roles/gpu/tasks/debian.yml
@@ -1,12 +1,25 @@
 ---
-- name: Ensure nvidia-container-toolkit apt GPG key
-  ansible.builtin.apt_key:
-    url: https://nvidia.github.io/libnvidia-container/gpgkey
-    keyring: /etc/apt/trusted.gpg.d/libnvidia-container.gpg
+# deb822_repository needs the python3-debian bindings on the target
+- name: Ensure python3-debian for deb822_repository
+  ansible.builtin.apt:
+    name: python3-debian
     state: present
 
 - name: Ensure nvidia-container-toolkit repo
-  ansible.builtin.apt_repository:
-    repo: deb [signed-by=/etc/apt/trusted.gpg.d/libnvidia-container.gpg] https://nvidia.github.io/libnvidia-container/stable/deb/$(ARCH) /
+  ansible.builtin.deb822_repository:
+    name: nvidia-container-toolkit
+    types: deb
+    uris: https://nvidia.github.io/libnvidia-container/stable/deb/$(ARCH)
+    suites: /
+    signed_by: https://nvidia.github.io/libnvidia-container/gpgkey
     state: present
-    filename: nvidia-container-toolkit
+  ignore_errors: '{{ ansible_check_mode }}'
+
+# Drop the pre-deb822 key and repo files so apt doesn't see the repo twice
+- name: Remove legacy apt key and repo files
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /etc/apt/sources.list.d/nvidia-container-toolkit.list
+    - /etc/apt/trusted.gpg.d/libnvidia-container.gpg

--- a/roles/hmsdocker/defaults/main/cloudflare.yml
+++ b/roles/hmsdocker/defaults/main/cloudflare.yml
@@ -10,9 +10,7 @@ cloudflare_api_token: ""
 cloudflare_ddns_domain: "{{ hms_docker_domain }}"
 
 # The DNS zone (registered domain) the DDNS record lives in // default: last two labels of cloudflare_ddns_domain
-# The default is derived from the last two labels of the domain, which is wrong for
-# multi-label public suffixes (e.g. "example.co.uk" would become "co.uk") — set the
-# zone explicitly if your domain uses one.
+# Set explicitly for multi-label public suffixes (e.g. "example.co.uk" would otherwise become "co.uk")
 cloudflare_ddns_zone: "{{ cloudflare_ddns_domain.split('.')[-2:] | join('.') }}"
 
 # The A (or AAAA) record to be created // default: "hmsdpublic"

--- a/roles/hmsdocker/defaults/main/cloudflare.yml
+++ b/roles/hmsdocker/defaults/main/cloudflare.yml
@@ -9,6 +9,12 @@ cloudflare_api_token: ""
 # Automatically uses the same domain defined in `main.yml`
 cloudflare_ddns_domain: "{{ hms_docker_domain }}"
 
+# The DNS zone (registered domain) the DDNS record lives in // default: last two labels of cloudflare_ddns_domain
+# The default is derived from the last two labels of the domain, which is wrong for
+# multi-label public suffixes (e.g. "example.co.uk" would become "co.uk") — set the
+# zone explicitly if your domain uses one.
+cloudflare_ddns_zone: "{{ cloudflare_ddns_domain.split('.')[-2:] | join('.') }}"
+
 # The A (or AAAA) record to be created // default: "hmsdpublic"
 cloudflare_ddns_subdomain: hmsdpublic
 

--- a/roles/hmsdocker/defaults/main/hmsd_advanced.yml
+++ b/roles/hmsdocker/defaults/main/hmsd_advanced.yml
@@ -7,6 +7,9 @@ hms_docker_data_path: "/opt/{{ project_name }}"
 # Where the container data is stored // default: "{{ hms_docker_data_path }}/apps"
 hms_docker_apps_path: "{{ hms_docker_data_path }}/apps"
 
+# Where the media library folders are created, recommended to leave this alone // default: "{{ hmsdocker_primary_mount_path }}/{{ hms_docker_library_folder_name }}"
+hmsdocker_library_path: "{{ hmsdocker_primary_mount_path }}/{{ hms_docker_library_folder_name }}"
+
 # Ownership of the secrets (.env) file
 secrets_env_user: root
 secrets_env_group: root

--- a/roles/hmsdocker/tasks/app_api_key_reader.yml
+++ b/roles/hmsdocker/tasks/app_api_key_reader.yml
@@ -227,8 +227,7 @@
         {% endif %}
         {% set _ = res.update({item.name: parsed}) %}
       {% endfor %}
-      {# to_json survives the render-to-string round trip even when config
-         values contain quotes; the dict's Python repr does not. #}
+      {# Serialize as JSON so values containing quotes survive the render round trip. #}
       {{ res | to_json }}
 
 - name: (API Key Reader) Initialize empty API keys dict

--- a/roles/hmsdocker/tasks/app_api_key_reader.yml
+++ b/roles/hmsdocker/tasks/app_api_key_reader.yml
@@ -187,7 +187,7 @@
   no_log: "{{ not debug_mode }}"
   ansible.builtin.set_fact:
     ansible_fact_cachable: false
-    service_configs: "{{ result | trim | from_yaml }}"
+    service_configs: "{{ result | trim | from_json }}"
   vars:
     configs:
       # Sabnzbd is not here because it does not have valid INI file syntax by default and adding support for it was too much of a pain
@@ -227,7 +227,9 @@
         {% endif %}
         {% set _ = res.update({item.name: parsed}) %}
       {% endfor %}
-      {{ res }}
+      {# to_json survives the render-to-string round trip even when config
+         values contain quotes; the dict's Python repr does not. #}
+      {{ res | to_json }}
 
 - name: (API Key Reader) Initialize empty API keys dict
   no_log: "{{ not debug_mode }}"

--- a/roles/hmsdocker/tasks/arr-scripts.yml
+++ b/roles/hmsdocker/tasks/arr-scripts.yml
@@ -32,7 +32,7 @@
   when:
     - item in enabled_containers
     - separate_4k_instances_enable | default(false)
-    - arr_script_app_config_dirs.results | selectattr('item', 'equalto', item) | selectattr('stat.exists', 'equalto', true) | list | length > 0
+    - arr_script_app_config_dirs.results | selectattr('item', 'equalto', item + '-4k') | selectattr('stat.exists', 'equalto', true) | list | length > 0
   ansible.builtin.get_url:
     url: https://raw.githubusercontent.com/RandomNinjaAtk/arr-scripts/main/{{ item }}/scripts_init.bash
     dest: "{{ hms_docker_apps_path }}/{{ item }}-4k/custom-cont-init.d"

--- a/roles/hmsdocker/tasks/compat_shim.yml
+++ b/roles/hmsdocker/tasks/compat_shim.yml
@@ -33,6 +33,20 @@
         | list
       }}
 
+# hostvars contains inventory-sourced vars but not role defaults, so it
+# distinguishes "the user set this new name" from "this only has a role
+# default". Snapshot it BEFORE aliasing: the aliasing set_fact itself adds
+# new names to hostvars, which would poison the check afterwards.
+- name: (compat) Snapshot which new names the user set explicitly
+  ansible.builtin.set_fact:
+    hmsdocker_user_set_new_names: >-
+      {{
+        hmsdocker_active_migrations
+        | map(attribute='new')
+        | select('in', hostvars[inventory_hostname])
+        | list
+      }}
+
 - name: (compat) Alias deprecated variables to their new names
   ansible.builtin.set_fact:
     "{{ item.new }}": "{{ lookup('vars', item.old) }}"
@@ -41,7 +55,13 @@
     label: "{{ item.old }} -> {{ item.new }}"
   # Skip null / empty old values: Jinja stringifies None as the literal
   # "None", which would silently bypass downstream length-based asserts.
-  when: (lookup('vars', item.old) | default('', true) | string) | length > 0
+  #
+  # Also skip when the user explicitly set the NEW name in their inventory:
+  # set_fact outranks group_vars, so aliasing here would silently clobber
+  # their value with the stale old one.
+  when:
+    - (lookup('vars', item.old) | default('', true) | string) | length > 0
+    - item.new not in hmsdocker_user_set_new_names
   # Old values may include credentials (e.g. transmission_vpn_pass).
   # Match the rest of preflight's no_log pattern.
   no_log: "{{ not (debug_mode | default(false) | bool) }}"
@@ -51,8 +71,15 @@
     hmsdocker_preflight_warnings: >-
       {{
         hmsdocker_preflight_warnings
-        + ["DEPRECATED: '" ~ item.old ~ "' has been renamed to '" ~ item.new
-           ~ "'. Update your inventory (or run `make update`) - the old name will be removed in a future release."]
+        + [
+            ("DEPRECATED: '" ~ item.old ~ "' has been renamed to '" ~ item.new
+             ~ "'. Both are set in your inventory; the value of '" ~ item.new
+             ~ "' is used and the old name is ignored. Remove '" ~ item.old ~ "'.")
+            if item.new in hmsdocker_user_set_new_names
+            else
+            ("DEPRECATED: '" ~ item.old ~ "' has been renamed to '" ~ item.new
+             ~ "'. Update your inventory (or run `make update`) - the old name will be removed in a future release.")
+          ]
       }}
   loop: "{{ hmsdocker_active_migrations }}"
   loop_control:

--- a/roles/hmsdocker/tasks/compat_shim.yml
+++ b/roles/hmsdocker/tasks/compat_shim.yml
@@ -33,10 +33,9 @@
         | list
       }}
 
-# hostvars contains inventory-sourced vars but not role defaults, so it
-# distinguishes "the user set this new name" from "this only has a role
-# default". Snapshot it BEFORE aliasing: the aliasing set_fact itself adds
-# new names to hostvars, which would poison the check afterwards.
+# hostvars holds inventory-sourced vars but not role defaults, so membership
+# means the user explicitly set the new name. Must be snapshotted before
+# aliasing — the aliasing set_fact adds the new names to hostvars.
 - name: (compat) Snapshot which new names the user set explicitly
   ansible.builtin.set_fact:
     hmsdocker_user_set_new_names: >-
@@ -55,10 +54,8 @@
     label: "{{ item.old }} -> {{ item.new }}"
   # Skip null / empty old values: Jinja stringifies None as the literal
   # "None", which would silently bypass downstream length-based asserts.
-  #
-  # Also skip when the user explicitly set the NEW name in their inventory:
-  # set_fact outranks group_vars, so aliasing here would silently clobber
-  # their value with the stale old one.
+  # Skip names the user already set: set_fact outranks group_vars and would
+  # clobber their value with the stale old one.
   when:
     - (lookup('vars', item.old) | default('', true) | string) | length > 0
     - item.new not in hmsdocker_user_set_new_names

--- a/roles/hmsdocker/tasks/main.yml
+++ b/roles/hmsdocker/tasks/main.yml
@@ -364,8 +364,7 @@
     - name: Import App Init task
       ansible.builtin.import_tasks: "app_inits/app_init.yml"
 
-# Saved last so a failed run doesn't record the new version and suppress the
-# upgrade/migration prompts in versioning.yml on the retry.
+# Saved last so a failed run re-prompts in versioning.yml on retry.
 - name: Save current version to file
   ansible.builtin.copy:
     content: "{{ hmsd_current_version }}"

--- a/roles/hmsdocker/tasks/main.yml
+++ b/roles/hmsdocker/tasks/main.yml
@@ -363,3 +363,13 @@
 
     - name: Import App Init task
       ansible.builtin.import_tasks: "app_inits/app_init.yml"
+
+# Saved last so a failed run doesn't record the new version and suppress the
+# upgrade/migration prompts in versioning.yml on the retry.
+- name: Save current version to file
+  ansible.builtin.copy:
+    content: "{{ hmsd_current_version }}"
+    dest: "{{ hmsd_version_file }}"
+    owner: "{{ container_uid }}"
+    group: "{{ container_gid }}"
+    mode: '0644'

--- a/roles/hmsdocker/tasks/versioning.yml
+++ b/roles/hmsdocker/tasks/versioning.yml
@@ -38,15 +38,14 @@
   register: last_version_content
   when: version_file_check.stat.exists
 
-# Releases 1.4 through 1.9 wrote 2-part versions (e.g. "1.9") to the version
-# file, and an interrupted write can leave it empty. The strict semver
-# comparisons below reject both, so pad the on-disk value to a full X.Y.Z and
-# fall back to 0.0.0 for anything unparseable.
+# Releases 1.4-1.9 wrote 2-part versions (e.g. "1.9") and an interrupted write
+# can leave the file empty; strict semver rejects both. Pad to X.Y.Z and fall
+# back to 0.0.0 for anything semver would reject (including leading zeros).
 - name: Decode and normalize last version
   ansible.builtin.set_fact:
     last_version: >-
       {{
-        (((raw_last_version if raw_last_version is match('^\d+(\.\d+){0,2}$') else '0.0.0')
+        (((raw_last_version if raw_last_version is match('^(0|[1-9]\d*)(\.(0|[1-9]\d*)){0,2}$') else '0.0.0')
           .split('.')) + ['0', '0'])[:3] | join('.')
       }}
   vars:
@@ -56,7 +55,7 @@
 - name: Validate current playbook version is 3-part semver
   ansible.builtin.assert:
     that:
-      - hmsd_current_version | string is match('^\d+\.\d+\.\d+$')
+      - hmsd_current_version | string is match('^(0|[1-9]\d*)(\.(0|[1-9]\d*)){2}$')
     fail_msg: >-
       hmsd_current_version ('{{ hmsd_current_version }}') must be a quoted 3-part
       version (X.Y.Z) in hms-docker.yml. Unquoted 2-part values like 1.20 are
@@ -135,6 +134,5 @@
             msg: "Playbook execution aborted."
           when: continue_playbook_v1_12_update.user_input | lower != "yes"
 
-# The version file is saved at the END of the role (see tasks/main.yml) so a
-# failed run doesn't record the new version and suppress migration prompts on
-# the retry.
+# The version file itself is saved at the end of tasks/main.yml so a failed
+# run re-prompts on retry.

--- a/roles/hmsdocker/tasks/versioning.yml
+++ b/roles/hmsdocker/tasks/versioning.yml
@@ -38,10 +38,30 @@
   register: last_version_content
   when: version_file_check.stat.exists
 
-- name: Decode last version
+# Releases 1.4 through 1.9 wrote 2-part versions (e.g. "1.9") to the version
+# file, and an interrupted write can leave it empty. The strict semver
+# comparisons below reject both, so pad the on-disk value to a full X.Y.Z and
+# fall back to 0.0.0 for anything unparseable.
+- name: Decode and normalize last version
   ansible.builtin.set_fact:
-    last_version: "{{ last_version_content.content | b64decode | trim }}"
+    last_version: >-
+      {{
+        (((raw_last_version if raw_last_version is match('^\d+(\.\d+){0,2}$') else '0.0.0')
+          .split('.')) + ['0', '0'])[:3] | join('.')
+      }}
+  vars:
+    raw_last_version: "{{ last_version_content.content | b64decode | trim }}"
   when: version_file_check.stat.exists
+
+- name: Validate current playbook version is 3-part semver
+  ansible.builtin.assert:
+    that:
+      - hmsd_current_version | string is match('^\d+\.\d+\.\d+$')
+    fail_msg: >-
+      hmsd_current_version ('{{ hmsd_current_version }}') must be a quoted 3-part
+      version (X.Y.Z) in hms-docker.yml. Unquoted 2-part values like 1.20 are
+      parsed by YAML as the float 1.2 and break semver comparison.
+    quiet: true
 
 - name: Compare versions and prompt if newer
   when: hmsd_current_version is version(last_version, '>', version_type='semver') and hmsd_data_dir.stat.exists and not (is_github_runner | default(false))
@@ -64,6 +84,11 @@
           Do you want to continue? (yes/no)
       register: continue_playbook
 
+    - name: Fail if user does not want to continue
+      ansible.builtin.fail:
+        msg: "Playbook execution aborted."
+      when: continue_playbook.user_input | lower != "yes"
+
     - name: Hardlink path migration version prompt
       when: last_version is version('0.2.0', '<', version_type='semver')
       block:
@@ -74,7 +99,7 @@
               Version 0.2 (you are on version {{ last_version }}) changed the paths that media and downloads are mounted to within containers.
               You will need to update the apps config to point to the new location in the container after the playbook run.
 
-              Do you want to continue? (yes/no)"
+              Do you want to continue? (yes/no)
           register: continue_playbook_hardlink_update
 
         - name: Fail if user does not want to continue
@@ -102,7 +127,7 @@
               - Remove Authentik protection from Authentik
               - Additional Traefik hardening
 
-              Do you want to continue? (yes/no)"
+              Do you want to continue? (yes/no)
           register: continue_playbook_v1_12_update
 
         - name: Fail if user does not want to continue
@@ -110,15 +135,6 @@
             msg: "Playbook execution aborted."
           when: continue_playbook_v1_12_update.user_input | lower != "yes"
 
-    - name: Fail if user does not want to continue
-      ansible.builtin.fail:
-        msg: "Playbook execution aborted."
-      when: continue_playbook.user_input | lower != "yes"
-
-- name: Save current version to file
-  ansible.builtin.copy:
-    content: "{{ hmsd_current_version }}"
-    dest: "{{ hmsd_version_file }}"
-    owner: "{{ container_uid }}"
-    group: "{{ container_gid }}"
-    mode: '0644'
+# The version file is saved at the END of the role (see tasks/main.yml) so a
+# failed run doesn't record the new version and suppress migration prompts on
+# the retry.

--- a/roles/hmsdocker/tasks/vpn_setup.yml
+++ b/roles/hmsdocker/tasks/vpn_setup.yml
@@ -9,7 +9,13 @@
     - transmission
     - qbittorrent
     - deluge
-  when: item in enabled_containers and item != 'transmission' or (item == 'transmission' and hmsdocker_vpn_provider == 'custom' and hmsdocker_vpn_type == 'openvpn')
+  # Transmission only needs the config dir when the user supplies their own
+  # openvpn config; the other clients always get one. The enabled check applies
+  # to every client — the old and/or grouping skipped it for transmission.
+  when: >-
+    item in enabled_containers
+    and (item != 'transmission'
+         or (hmsdocker_vpn_provider == 'custom' and hmsdocker_vpn_type == 'openvpn'))
 
 # Skip the stub for PIA, which generates its own wg0.conf (an empty one aborts it).
 - name: (VPN Setup) Ensure WireGuard config exists with restricted permissions

--- a/roles/hmsdocker/tasks/vpn_setup.yml
+++ b/roles/hmsdocker/tasks/vpn_setup.yml
@@ -10,8 +10,7 @@
     - qbittorrent
     - deluge
   # Transmission only needs the config dir when the user supplies their own
-  # openvpn config; the other clients always get one. The enabled check applies
-  # to every client — the old and/or grouping skipped it for transmission.
+  # openvpn config; the other clients always get one.
   when: >-
     item in enabled_containers
     and (item != 'transmission'

--- a/roles/hmsdocker/tasks/vpn_validation.yml
+++ b/roles/hmsdocker/tasks/vpn_validation.yml
@@ -35,47 +35,45 @@
 # Fail closed: a container stays running only if its VPN IP was positively
 # verified to differ from the host public IP; failed or empty lookups count
 # as unverified.
-- name: Ensure public IP and VPN public IP are different
-  ansible.builtin.debug:
-    msg:
-      - Your public IP is protected in {{ item.item }}!
-      - "Current public IP: {{ hmsd_host_public_ip }}"
-      - "Current {{ item.item }} VPN IP: {{ item.vpn_ip }}"
+- name: Validate VPN protection per download client
   vars:
     hmsd_host_public_ip: "{{ ansible_facts['ipify_public_ip'] | default('') }}"
-  when:
-    - not ansible_check_mode
-    - not item.skipped
-    - hmsd_host_public_ip | length > 0
-    - item.vpn_ip | length > 0
-    - hmsd_host_public_ip != item.vpn_ip
-  loop: "{{ slimmed_vpn_public_ip_results }}"
+  block:
+    - name: Ensure public IP and VPN public IP are different
+      ansible.builtin.debug:
+        msg:
+          - Your public IP is protected in {{ item.item }}!
+          - "Current public IP: {{ hmsd_host_public_ip }}"
+          - "Current {{ item.item }} VPN IP: {{ item.vpn_ip }}"
+      when:
+        - not ansible_check_mode
+        - not item.skipped
+        - hmsd_host_public_ip | length > 0
+        - item.vpn_ip | length > 0
+        - hmsd_host_public_ip != item.vpn_ip
+      loop: "{{ slimmed_vpn_public_ip_results }}"
 
-- name: Stop VPN container if protection could not be verified
-  community.docker.docker_compose_v2:
-    project_src: "{{ hms_docker_data_path }}"
-    project_name: "{{ project_name }}"
-    state: stopped
-    remove_orphans: "{{ container_remove_orphans }}"
-    services:
-      - "{{ item.item }}"
-  vars:
-    hmsd_host_public_ip: "{{ ansible_facts['ipify_public_ip'] | default('') }}"
-  loop: "{{ slimmed_vpn_public_ip_results }}"
-  when:
-    - not item.skipped
-    - hmsd_host_public_ip == '' or item.vpn_ip == '' or hmsd_host_public_ip == item.vpn_ip
+    - name: Stop VPN container if protection could not be verified
+      community.docker.docker_compose_v2:
+        project_src: "{{ hms_docker_data_path }}"
+        project_name: "{{ project_name }}"
+        state: stopped
+        remove_orphans: "{{ container_remove_orphans }}"
+        services:
+          - "{{ item.item }}"
+      loop: "{{ slimmed_vpn_public_ip_results }}"
+      when:
+        - not item.skipped
+        - hmsd_host_public_ip == '' or item.vpn_ip == '' or hmsd_host_public_ip == item.vpn_ip
 
-- name: Print error message if VPN protection could not be verified
-  ansible.builtin.debug:
-    msg:
-      - 🔴 Your public IP is NOT verified as protected in {{ item.item }}! 🔴
-      - "Current public IP: {{ hmsd_host_public_ip if hmsd_host_public_ip else '(lookup failed)' }}"
-      - "Current {{ item.item }} VPN IP: {{ item.vpn_ip if item.vpn_ip else '(lookup failed)' }}"
-      - 🔴 The {{ item.item }} container has been stopped 🔴
-  vars:
-    hmsd_host_public_ip: "{{ ansible_facts['ipify_public_ip'] | default('') }}"
-  loop: "{{ slimmed_vpn_public_ip_results }}"
-  when:
-    - not item.skipped
-    - hmsd_host_public_ip == '' or item.vpn_ip == '' or hmsd_host_public_ip == item.vpn_ip
+    - name: Print error message if VPN protection could not be verified
+      ansible.builtin.debug:
+        msg:
+          - 🔴 Your public IP is NOT verified as protected in {{ item.item }}! 🔴
+          - "Current public IP: {{ hmsd_host_public_ip if hmsd_host_public_ip else '(lookup failed)' }}"
+          - "Current {{ item.item }} VPN IP: {{ item.vpn_ip if item.vpn_ip else '(lookup failed)' }}"
+          - 🔴 The {{ item.item }} container has been stopped 🔴
+      loop: "{{ slimmed_vpn_public_ip_results }}"
+      when:
+        - not item.skipped
+        - hmsd_host_public_ip == '' or item.vpn_ip == '' or hmsd_host_public_ip == item.vpn_ip

--- a/roles/hmsdocker/tasks/vpn_validation.yml
+++ b/roles/hmsdocker/tasks/vpn_validation.yml
@@ -32,20 +32,26 @@
   loop: "{{ vpn_public_ip.results }}"
   no_log: "{{ not debug_mode }}"
 
+# Fail closed: a container is only left running if we positively verified its
+# VPN IP differs from the host public IP. A failed ipify lookup or an empty
+# in-container result counts as unverified, not as protected.
 - name: Ensure public IP and VPN public IP are different
   ansible.builtin.debug:
     msg:
       - Your public IP is protected in {{ item.item }}!
-      - "Current public IP: {{ ansible_facts['ipify_public_ip'] }}"
+      - "Current public IP: {{ hmsd_host_public_ip }}"
       - "Current {{ item.item }} VPN IP: {{ item.vpn_ip }}"
+  vars:
+    hmsd_host_public_ip: "{{ ansible_facts['ipify_public_ip'] | default('') }}"
   when:
     - not ansible_check_mode
     - not item.skipped
-    - ansible_facts['ipify_public_ip'] is defined
-    - ansible_facts['ipify_public_ip'] != item.vpn_ip
+    - hmsd_host_public_ip | length > 0
+    - item.vpn_ip | length > 0
+    - hmsd_host_public_ip != item.vpn_ip
   loop: "{{ slimmed_vpn_public_ip_results }}"
 
-- name: Stop VPN container if public IP and VPN IP match
+- name: Stop VPN container if protection could not be verified
   community.docker.docker_compose_v2:
     project_src: "{{ hms_docker_data_path }}"
     project_name: "{{ project_name }}"
@@ -53,21 +59,23 @@
     remove_orphans: "{{ container_remove_orphans }}"
     services:
       - "{{ item.item }}"
+  vars:
+    hmsd_host_public_ip: "{{ ansible_facts['ipify_public_ip'] | default('') }}"
   loop: "{{ slimmed_vpn_public_ip_results }}"
   when:
-    - not item.skipped | default(True)
-    - item.vpn_ip is defined
-    - ansible_facts['ipify_public_ip'] == item.vpn_ip or ansible_facts['ipify_public_ip'] == '' or ansible_facts['ipify_public_ip'] is undefined
+    - not item.skipped
+    - hmsd_host_public_ip == '' or item.vpn_ip == '' or hmsd_host_public_ip == item.vpn_ip
 
-- name: Print error message if public IP and VPN IP are identical
+- name: Print error message if VPN protection could not be verified
   ansible.builtin.debug:
     msg:
-      - 🔴 Your public IP is NOT protected in {{ item.item }}! 🔴
-      - "Current public IP: {{ ansible_facts['ipify_public_ip'] }}"
-      - "Current {{ item.item }} VPN IP: {{ item.vpn_ip }}"
+      - 🔴 Your public IP is NOT verified as protected in {{ item.item }}! 🔴
+      - "Current public IP: {{ hmsd_host_public_ip if hmsd_host_public_ip else '(lookup failed)' }}"
+      - "Current {{ item.item }} VPN IP: {{ item.vpn_ip if item.vpn_ip else '(lookup failed)' }}"
       - 🔴 The {{ item.item }} container has been stopped 🔴
+  vars:
+    hmsd_host_public_ip: "{{ ansible_facts['ipify_public_ip'] | default('') }}"
   loop: "{{ slimmed_vpn_public_ip_results }}"
   when:
-    - not item.skipped | default(True)
-    - item.vpn_ip is defined
-    - ansible_facts['ipify_public_ip'] == item.vpn_ip or ansible_facts['ipify_public_ip'] == '' or ansible_facts['ipify_public_ip'] is undefined
+    - not item.skipped
+    - hmsd_host_public_ip == '' or item.vpn_ip == '' or hmsd_host_public_ip == item.vpn_ip

--- a/roles/hmsdocker/tasks/vpn_validation.yml
+++ b/roles/hmsdocker/tasks/vpn_validation.yml
@@ -32,9 +32,9 @@
   loop: "{{ vpn_public_ip.results }}"
   no_log: "{{ not debug_mode }}"
 
-# Fail closed: a container is only left running if we positively verified its
-# VPN IP differs from the host public IP. A failed ipify lookup or an empty
-# in-container result counts as unverified, not as protected.
+# Fail closed: a container stays running only if its VPN IP was positively
+# verified to differ from the host public IP; failed or empty lookups count
+# as unverified.
 - name: Ensure public IP and VPN public IP are different
   ansible.builtin.debug:
     msg:

--- a/roles/hmsdocker/templates/env.j2
+++ b/roles/hmsdocker/templates/env.j2
@@ -43,7 +43,7 @@ TRAEFIK_TAG={{ hmsdocker_traefik_version | default('latest') }}
 ### BEGIN Cloudflare
 CLOUDFLARE_API_TOKEN={{ cloudflare_api_token }}
 # Ensures only DNS zone is used
-CLOUDFLARE_DOMAIN={{ cloudflare_ddns_domain.split('.')[-2:] | join('.') }}
+CLOUDFLARE_DOMAIN={{ cloudflare_ddns_zone }}
 CLOUDFLARE_TUNNEL_TOKEN={{ cloudflare_tunnel_token }}
 ### END Cloudflare
 
@@ -57,9 +57,9 @@ AUTHENTIK_SECRET_KEY={{ authentik_key -}}
 PG_PASS={{ authentik_pgpass -}}
 PG_USER={{ authentik_pgu }}
 PG_DB={{ authentik_pgdb }}
-{% if authentik_geoip_account_id != '' and authentik_geoip_license_key != '' | default(False) %}
-GEOIP_ACC_ID: "{{ authentik_geoip_account_id }}"
-GEOIP_LIC_KEY: "{{ authentik_geoip_license_key }}"
+{% if (authentik_geoip_account_id | default('')) != '' and (authentik_geoip_license_key | default('')) != '' %}
+GEOIP_ACC_ID={{ authentik_geoip_account_id }}
+GEOIP_LIC_KEY={{ authentik_geoip_license_key }}
 {% endif %}
 ### END Authentik
 {% endif %}

--- a/roles/hmsdocker/vars/main.yml
+++ b/roles/hmsdocker/vars/main.yml
@@ -3,8 +3,9 @@
 #######################################################################
 ### Misc
 hmsdocker_primary_mount_path: "{{ hms_docker_mount_path }}/{{ hms_docker_primary_mount_name }}"
-# This just combines the mount path and media folder name, recommended to leave this alone // default: "{{ hmsdocker_primary_mount_path }}/{{ hms_docker_library_folder_name }}"
-hmsdocker_library_path: "{{ hmsdocker_primary_mount_path }}/{{ hms_docker_library_folder_name }}"
+# hmsdocker_library_path lives in defaults/main/hmsd_advanced.yml (role
+# defaults) rather than here: role vars outrank inventory group_vars, which
+# would make the documented override in user inventory silently ineffective.
 #######################################################################
 
 

--- a/roles/hmsdocker/vars/main.yml
+++ b/roles/hmsdocker/vars/main.yml
@@ -3,9 +3,8 @@
 #######################################################################
 ### Misc
 hmsdocker_primary_mount_path: "{{ hms_docker_mount_path }}/{{ hms_docker_primary_mount_name }}"
-# hmsdocker_library_path lives in defaults/main/hmsd_advanced.yml (role
-# defaults) rather than here: role vars outrank inventory group_vars, which
-# would make the documented override in user inventory silently ineffective.
+# hmsdocker_library_path is in defaults/main/hmsd_advanced.yml — as a role
+# var here it would shadow inventory overrides.
 #######################################################################
 
 


### PR DESCRIPTION
## Summary

This PR addresses several robustness issues across version management, VPN validation, variable compatibility, and the release workflow. The changes ensure safer version comparisons, clearer error messaging, and prevent edge cases in automation.

## Key Changes

### Version Management (`roles/hmsdocker/tasks/versioning.yml`)
- **Normalize on-disk versions** before semver comparison: releases 1.4–1.9 wrote 2-part versions (e.g., "1.9") and interrupted writes can leave the file empty. Now pads these to X.Y.Z format and falls back to 0.0.0 for unparseable values.
- **Add runtime assertion** that `hmsd_current_version` is a quoted 3-part semver. Unquoted values like `1.20` are parsed by YAML as the float `1.2`, breaking semver comparison for all users. The assert provides a clear error message.
- **Move version file save to end of playbook** (`roles/hmsdocker/tasks/main.yml`): failed runs no longer record the new version, allowing migration prompts to re-trigger on retry.
- **Restructure user-continuation logic**: move the main "do you want to continue?" failure check outside nested blocks to prevent duplicate checks.

### VPN Validation (`roles/hmsdocker/tasks/vpn_validation.yml`)
- **Fail closed on missing data**: containers are only left running if VPN IP is positively verified as different from host public IP. Failed ipify lookups or empty in-container results now count as unverified (not protected), triggering container stop.
- **Improve error messaging**: distinguish between "not protected" and "could not verify protection" with clearer debug output showing "(lookup failed)" when data is missing.
- **Simplify condition logic**: use explicit empty-string checks instead of `is defined` to handle missing facts more clearly.

### Variable Compatibility (`roles/hmsdocker/tasks/compat_shim.yml`)
- **Snapshot user-set new names before aliasing**: detect when users explicitly set the new variable name in inventory, preventing the aliasing logic from silently clobbering their value with a stale old one.
- **Improve deprecation warnings**: distinguish between "user set both old and new" (use new, remove old) and "only old is set" (migrate to new) with targeted messaging.

### Release Workflow (`.github/workflows/release.yml`)
- **Check if version is already tagged** before attempting release: the workflow triggers on any push touching `hms-docker.yml`, not just version bumps. Skip release creation if the tag already exists.
- **Add changelog validation**: fail with a clear error if no release notes are found under the expected `## v<version>` heading.
- **Fix tag cleanup logic**: only delete a tag if this run actually created it (`steps.tag_version.outcome == 'success'`), never a pre-existing one.

### Template & Configuration Fixes
- **Cloudflare DDNS** (`roles/hmsdocker/templates/env.j2`, `roles/hmsdocker/defaults/main/cloudflare.yml`): introduce `cloudflare_ddns_zone` variable to handle multi-label public suffixes (e.g., "example.co.uk") correctly. Users can now override the zone explicitly instead of relying on a fragile split of the domain.
- **Authentik GeoIP config** (`roles/hmsdocker/templates/env.j2`): fix Jinja syntax (remove colons, add proper `default()` filters) and use `to_json` instead of `to_yaml` for safer template rendering.
- **VPN setup condition** (`roles/hmsdocker/tasks/vpn_setup.yml`): clarify that transmission only needs VPN config when using custom OpenVPN; rewrite condition for readability.
- **API key reader** (`roles/hmsdocker/tasks/app_api_key_reader.yml`): output config dict as JSON instead of YAML repr to survive quote-containing values.
- **Container check script** (`.github/workflows/scripts/check_containers.py`): allow `HMSD_PROJECT_NAME` env var override for custom project names.

https://claude.ai/code/session_018kYsjE9hrxfFoXsUN6npTb