### PR TITLE
fix(makefile): make `make manager` recover from a broken venv (#219)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,11 @@ CUSTOM_CONF_DIR = inventory/group_vars/all
 
 REMOTE_CONFIG_URL = https://hmsdocker.dev/configs
 
+VENV_DIR = .venv
+VENV_PY = $(VENV_DIR)/bin/python3
+# Marker file used to detect when requirements.txt changed since the last install
+VENV_STAMP = $(VENV_DIR)/.requirements-installed
+
 ARCH = $(shell uname -m)
 BIN_DIR = ./bin
 YQ_LOCAL = $(BIN_DIR)/yq
@@ -80,13 +85,32 @@ verify-containers:
 	@sudo python3 .github/workflows/scripts/check_containers.py
 
 manager:
-	@if [ ! -d ".venv" ]; then \
+	@set -e; \
+	if [ -d "$(VENV_DIR)" ] && ! "$(VENV_PY)" -m pip --version > /dev/null 2>&1; then \
+		printf $(_WARN) "WARN" "Found an incomplete virtual environment in '$(VENV_DIR)', recreating it"; \
+		rm -rf "$(VENV_DIR)"; \
+	fi; \
+	if [ ! -d "$(VENV_DIR)" ]; then \
 		echo "Creating Python virtual environment"; \
-		python3 -m venv .venv; \
+		if ! python3 -m venv "$(VENV_DIR)"; then \
+			rm -rf "$(VENV_DIR)"; \
+			pyver=$$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])' 2>/dev/null); \
+			printf $(_ERROR) "FAIL" "Could not create the Python virtual environment in '$(VENV_DIR)'"; \
+			printf $(_ERROR) "FAIL" "On Debian/Ubuntu, install the venv module and re-run 'make manager':"; \
+			printf $(_ERROR) "FAIL" "  sudo apt install -y python3-venv python$$pyver-venv"; \
+			exit 1; \
+		fi; \
+	fi; \
+	if [ ! -f "$(VENV_STAMP)" ] || [ requirements.txt -nt "$(VENV_STAMP)" ]; then \
 		echo "Installing Python requirements"; \
-		.venv/bin/pip3 install -r requirements.txt > /dev/null; \
-	fi;
-	@.venv/bin/python3 settings_manager.py
+		if ! "$(VENV_DIR)/bin/pip3" install -r requirements.txt > "$(VENV_DIR)/pip-install.log" 2>&1; then \
+			cat "$(VENV_DIR)/pip-install.log"; \
+			printf $(_ERROR) "FAIL" "Failed to install Python requirements from requirements.txt"; \
+			exit 1; \
+		fi; \
+		touch "$(VENV_STAMP)"; \
+	fi
+	@$(VENV_PY) settings_manager.py
 
 update: $(YQ_LOCAL)
 	@echo "Version Before: $$($(YQ_LOCAL) '.[0].vars.hmsd_current_version' hms-docker.yml)"

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,11 @@ verify-containers:
 manager:
 	@set -e; \
 	if [ -d "$(VENV_DIR)" ] && ! "$(VENV_PY)" -m pip --version > /dev/null 2>&1; then \
+		if [ ! -w "$(VENV_DIR)" ]; then \
+			printf $(_ERROR) "FAIL" "'$(VENV_DIR)' is incomplete and not writable by $$(id -un), remove it and re-run 'make manager':"; \
+			printf $(_ERROR) "FAIL" "  sudo rm -rf $(VENV_DIR)"; \
+			exit 1; \
+		fi; \
 		printf $(_WARN) "WARN" "Found an incomplete virtual environment in '$(VENV_DIR)', recreating it"; \
 		rm -rf "$(VENV_DIR)"; \
 	fi; \
@@ -94,21 +99,32 @@ manager:
 		echo "Creating Python virtual environment"; \
 		if ! python3 -m venv "$(VENV_DIR)"; then \
 			rm -rf "$(VENV_DIR)"; \
-			pyver=$$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])' 2>/dev/null); \
+			pyver=$$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])' 2>/dev/null) || pyver=""; \
 			printf $(_ERROR) "FAIL" "Could not create the Python virtual environment in '$(VENV_DIR)'"; \
 			printf $(_ERROR) "FAIL" "On Debian/Ubuntu, install the venv module and re-run 'make manager':"; \
-			printf $(_ERROR) "FAIL" "  sudo apt install -y python3-venv python$$pyver-venv"; \
+			if [ -n "$$pyver" ]; then \
+				printf $(_ERROR) "FAIL" "  sudo apt install -y python3-venv python$$pyver-venv"; \
+			else \
+				printf $(_ERROR) "FAIL" "  sudo apt install -y python3 python3-venv"; \
+			fi; \
 			exit 1; \
 		fi; \
 	fi; \
-	if [ ! -f "$(VENV_STAMP)" ] || [ requirements.txt -nt "$(VENV_STAMP)" ]; then \
+	if [ ! -w "$(VENV_DIR)" ]; then \
+		printf $(_WARN) "WARN" "'$(VENV_DIR)' is not writable by $$(id -un), skipping the requirements check"; \
+		printf $(_WARN) "WARN" "If the settings manager fails to start, run 'sudo rm -rf $(VENV_DIR)' and try again"; \
+	elif [ ! -f "$(VENV_STAMP)" ] || [ requirements.txt -nt "$(VENV_STAMP)" ]; then \
 		echo "Installing Python requirements"; \
-		if ! "$(VENV_DIR)/bin/pip3" install -r requirements.txt > "$(VENV_DIR)/pip-install.log" 2>&1; then \
-			cat "$(VENV_DIR)/pip-install.log"; \
+		piplog=$$(mktemp); \
+		if ! "$(VENV_PY)" -m pip install -r requirements.txt > "$$piplog" 2>&1; then \
+			cat "$$piplog"; \
+			rm -f "$$piplog"; \
 			printf $(_ERROR) "FAIL" "Failed to install Python requirements from requirements.txt"; \
 			exit 1; \
 		fi; \
-		touch "$(VENV_STAMP)"; \
+		rm -f "$$piplog"; \
+		touch "$(VENV_STAMP)" 2>/dev/null || \
+			printf $(_WARN) "WARN" "Could not write to '$(VENV_DIR)', requirements will be re-checked on every run"; \
 	fi
 	@$(VENV_PY) settings_manager.py
 

--- a/docs-astro/src/content/docs/docs/getting-started/install.mdx
+++ b/docs-astro/src/content/docs/docs/getting-started/install.mdx
@@ -39,9 +39,7 @@ This playbook configures Docker to use the `172.27.0.0/16` IP range for all Dock
 
     :::note
 
-    `python3-venv` is required by `make manager`. On some Ubuntu/Debian releases the generic
-    `python3-venv` package does not pull in the module for your interpreter, in which case also
-    install the versioned package (e.g. `sudo apt install python3.12-venv -y`).
+    `python3-venv` is required by `make manager`.
 
     :::
 

--- a/docs-astro/src/content/docs/docs/getting-started/install.mdx
+++ b/docs-astro/src/content/docs/docs/getting-started/install.mdx
@@ -34,8 +34,16 @@ This playbook configures Docker to use the `172.27.0.0/16` IP range for all Dock
 2. Install requirements:
 
     ```bash
-    sudo apt install git make python3-pip -y
+    sudo apt install git make python3-pip python3-venv -y
     ```
+
+    :::note
+
+    `python3-venv` is required by `make manager`. On some Ubuntu/Debian releases the generic
+    `python3-venv` package does not pull in the module for your interpreter, in which case also
+    install the versioned package (e.g. `sudo apt install python3.12-venv -y`).
+
+    :::
 
 3. Clone the repository:
 
@@ -75,6 +83,10 @@ There is a script that will allow you to easily edit all variable files mentione
 ```bash
 make manager
 ```
+
+This creates a Python virtual environment in `.venv/` on first run and installs the requirements
+into it. If the environment is missing or incomplete (for example, it was created before
+`python3-venv` was installed), it is rebuilt automatically.
 
 :::
 


### PR DESCRIPTION
`make manager` only checked whether the `.venv` directory existed. When
`python3 -m venv` failed because the `venv` module was missing, it left
behind a partial `.venv` (a `python3` symlink, no `pip`) and the recipe
kept going, so the run died on `.venv/bin/pip3: No such file or
directory`. Worse, every later invocation saw the leftover directory,
skipped creation entirely, and ran `settings_manager.py` against an empty
environment - failing with `ModuleNotFoundError: No module named
'ruamel'` until the user manually removed `.venv`.

- Validate the environment with `python3 -m pip --version` instead of a
  directory check, and rebuild it when it is incomplete.
- Abort with a clear message (and clean up the partial `.venv`) when the
  environment cannot be created, pointing at the `python3-venv` package
  for the running interpreter version.
- Fail the target when `pip install` fails, printing the captured log
  instead of discarding it to `/dev/null`.
- Reinstall requirements when `requirements.txt` is newer than the last
  install, tracked by a stamp file in the venv.

Docs: add `python3-venv` to the install prerequisites and note the
versioned package fallback.